### PR TITLE
Upgrade testenv image to PHP 8.4.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 
 # Pinned tool versions. This Dockerfile is the single source of truth; override
 # at build time with `--build-arg` if necessary.
-ARG PHP_VERSION=8.2.31
+ARG PHP_VERSION=8.4.21
 ARG PHAN_VERSION=6.0.5
 ARG PHP_AST_VERSION=1.1.3
 


### PR DESCRIPTION
## Summary
- Stacked on top of #2 (the version-pinning PR). Bumps `PHP_VERSION` from `8.2.31` → `8.4.21` (the latest 8.4 patch currently published as a Docker Hub `php` image; 8.4.22 exists on php.net but isn't on Docker Hub yet).
- Phan 6.0.5 and php-ast 1.1.3 are kept — both already support PHP 8.4 syntax.

## Test plan
- [x] `docker build --target=testenv .` succeeds against PHP 8.4.21.
- [x] In the resulting image, `php --version` reports 8.4.21 and `phan --version` reports 6.0.5 / php-ast 1.1.3.
- [ ] `grunt test:server` in the bga-theloop repo (which consumes `wardcanyon/localarena-testenv:latest`) still passes.
- [ ] `grunt phan` in the bga-theloop repo still passes (or any new findings are triaged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)