### PR TITLE
Add ParaTest to the testenv image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@
 ARG PHP_VERSION=8.2.31
 ARG PHAN_VERSION=6.0.5
 ARG PHP_AST_VERSION=1.1.3
+# ParaTest runs the game test suites in parallel across CPU cores. The 7.x line
+# is the one compatible with PHPUnit 11.
+ARG PARATEST_VERSION=7.8.5
 
 # The example below uses the PHP Apache image as the foundation for running the app.
 # If reproducability is important, consider using a specific digest SHA, like
@@ -75,6 +78,7 @@ FROM php:${PHP_VERSION}-cli AS testenv
 # the first FROM are only visible in FROM lines unless re-declared here.
 ARG PHAN_VERSION
 ARG PHP_AST_VERSION
+ARG PARATEST_VERSION
 
 # Install `php-ast` from PECL (required for `phan`)
 RUN pecl install ast-${PHP_AST_VERSION} && docker-php-ext-enable ast
@@ -90,6 +94,7 @@ RUN apt-get update -y && apt-get dist-upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN composer require --dev phpunit/phpunit ^11
+RUN composer require --dev brianium/paratest:${PARATEST_VERSION}
 RUN composer require --dev phan/phan:${PHAN_VERSION}
 ENV PATH="$PATH:/vendor/bin"
 


### PR DESCRIPTION
## Summary

Adds the `paratest` binary to the `wardcanyon/localarena-testenv` image so game test suites can run in parallel across CPU cores instead of in a single PHPUnit process.

This is the prerequisite image change for **wardcanyon/bga-theloop#27**, which switches `grunt test:server` to ParaTest. (Measured there: the full 424-test suite drops to ~4m15s across 8 cores.)

## Change

- New pinned `ARG PARATEST_VERSION=7.8.5`, declared globally and re-declared in the `testenv` stage (matching the existing `PHAN_VERSION` convention).
- `RUN composer require --dev brianium/paratest:${PARATEST_VERSION}` in the `testenv` stage, right after the PHPUnit require.

ParaTest 7.x is the line compatible with PHPUnit 11 (the image ships PHPUnit 11.5.55 / PHP 8.2).

## Verification

Built the `testenv` target from this change and confirmed the binary resolves on the PATH:

```
$ docker build --target testenv -t localarena-testenv:pr-verify .
$ docker run --rm localarena-testenv:pr-verify sh -c 'which paratest && paratest --version'
/vendor/bin/paratest
ParaTest v7.8.5
```

The same image (built locally with this exact `composer require`) was used to verify bga-theloop#27 end-to-end against the real test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)