### PR TITLE
Add GitHub Actions workflow for building and pushing Docker image

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,41 @@
+name: Build and push image
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-testenv
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx grunt build
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag image for GHCR
+        run: docker tag wardcanyon/localarena-testenv:latest ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+
+      - name: Push image
+        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -18,15 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - run: npm ci
-
-      - run: npx grunt build
-
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -34,8 +25,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Tag image for GHCR
-        run: docker tag wardcanyon/localarena-testenv:latest ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Push image
-        run: docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: testenv
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automates the building and pushing of a Docker image to GitHub Container Registry (GHCR).

## Key Changes
- Added `.github/workflows/build-and-push.yml` workflow file that:
  - Triggers on manual workflow dispatch
  - Authenticates with GHCR using GitHub token
  - Sets up Docker Buildx for multi-platform builds
  - Builds the Docker image targeting the `testenv` stage
  - Pushes the built image to GHCR with the `latest` tag
  - Leverages GitHub Actions cache for faster builds

## Implementation Details
- The workflow uses the `docker/build-push-action@v6` action for efficient image building and pushing
- GitHub Actions cache is configured for both cache source and destination to optimize build times
- The image is tagged as `ghcr.io/{repository}-testenv:latest`
- Workflow requires `contents: read` and `packages: write` permissions

https://claude.ai/code/session_015S6VufhTcB3NAMz8EUEnQ6