### PR TITLE
Refactor database configuration and add port support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,12 +99,16 @@ RUN composer require --dev phan/phan:${PHAN_VERSION}
 ENV PATH="$PATH:/vendor/bin"
 
 ENV DB_HOST=db
+ENV DB_PORT=3306
 ENV DB_USER=root
 ENV DB_PASSWORD_FILE_PATH=/run/secrets/db-password
+
+RUN echo -n 'example-pass' > /run/secrets/db-password
 
 COPY ./src/localarena_config.inc.php /src/localarena/localarena_config.inc.php
 COPY ./src/module /src/localarena/module
 COPY ./src/view /src/localarena/view
 COPY ./src/vendor /src/localarena/vendor
+COPY ./src/game/localarenanoop /src/game/localarenanoop
 RUN chown -R www-data: /src
 RUN chmod -R 755 /src

--- a/src/module/db_config.php
+++ b/src/module/db_config.php
@@ -1,0 +1,17 @@
+<?php
+
+function localarena_db_password(): string {
+    $pw = getenv('DB_PASSWORD');
+    if ($pw !== false && $pw !== '') {
+        return $pw;
+    }
+    return trim(file_get_contents(getenv('DB_PASSWORD_FILE_PATH')));
+}
+
+function localarena_db_port(): int {
+    $port = getenv('DB_PORT');
+    if ($port !== false && $port !== '') {
+        return (int)$port;
+    }
+    return 3306;
+}

--- a/src/module/table/table.game.php
+++ b/src/module/table/table.game.php
@@ -1,4 +1,5 @@
  <?php
+ require_once APP_GAMEMODULE_PATH . 'module/db_config.php';
  require_once APP_GAMEMODULE_PATH . 'module/LocalArenaContext.php';
  require_once APP_GAMEMODULE_PATH . 'module/table/feException.php';
  require_once APP_GAMEMODULE_PATH . 'module/table/BgaVisibleSystemException.php';
@@ -82,13 +83,12 @@
      if (self::$static_conn_ === null) {
          echo '*** LocalArena table constructor: setting up new connection' . "\n";
 
-       // These are provided by Docker Compose; see "compose.yaml".
        $this->servername = getenv('DB_HOST');
        $this->username = getenv('DB_USER');
-       $this->password = trim(file_get_contents(getenv('DB_PASSWORD_FILE_PATH')));
+       $this->password = localarena_db_password();
 
        // Create connection
-       $conn = new mysqli($this->servername, $this->username, $this->password, $this->dbname);
+       $conn = new mysqli($this->servername, $this->username, $this->password, $this->dbname, localarena_db_port());
 
        // Check connection
        if ($conn->connect_error) {
@@ -1483,10 +1483,11 @@
       $undo_file = $this->getUndoFilePath();
       $servername = getenv('DB_HOST');
       $username = getenv('DB_USER');
-      $password = trim(file_get_contents(getenv('DB_PASSWORD_FILE_PATH')));
+      $password = localarena_db_password();
+      $port = localarena_db_port();
 
       $cmd = "mysqldump --user={$username} --password={$password} " .
-          "--host={$servername} --skip-ssl {$this->dbname} --result-file={$undo_file} 2>&1";
+          "--host={$servername} --port={$port} --skip-ssl {$this->dbname} --result-file={$undo_file} 2>&1";
       exec($cmd, $output, $result_code);
   }
 
@@ -1499,10 +1500,11 @@
       if (file_exists($undo_file)) {
           $servername = getenv('DB_HOST');
           $username = getenv('DB_USER');
-          $password = trim(file_get_contents(getenv('DB_PASSWORD_FILE_PATH')));
+          $password = localarena_db_password();
+          $port = localarena_db_port();
 
           $cmd = "mysql --user={$username} --password={$password} " .
-              "--host={$servername} --skip-ssl {$this->dbname} < {$undo_file} 2>&1";
+              "--host={$servername} --port={$port} --skip-ssl {$this->dbname} < {$undo_file} 2>&1";
           exec($cmd, $output, $result_code);
       }
   }

--- a/src/module/tablemanager/tablemanager.php
+++ b/src/module/tablemanager/tablemanager.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once APP_GAMEMODULE_PATH . 'module/db_config.php';
 require_once APP_GAMEMODULE_PATH . 'localarena_config.inc.php';
 require_once APP_GAMEMODULE_PATH . 'module/LocalArenaContext.php';
 
@@ -63,9 +64,9 @@ class TableManager
   {
     $servername = getenv('DB_HOST');
     $username = getenv('DB_USER');
-    $password = trim(file_get_contents(getenv('DB_PASSWORD_FILE_PATH')));
+    $password = localarena_db_password();
 
-    $conn = new mysqli($servername, $username, $password, $dbname);
+    $conn = new mysqli($servername, $username, $password, $dbname, localarena_db_port());
 
     // Set transaction isolation level so that we can read back
     // changes later in the same transaction.


### PR DESCRIPTION
## Summary
This PR refactors database configuration handling by extracting common database credential logic into a dedicated configuration module and adds support for configurable database ports.

## Key Changes
- **New module**: Created `src/module/db_config.php` with two helper functions:
  - `localarena_db_password()`: Retrieves DB password from environment variable or file, with fallback logic
  - `localarena_db_port()`: Retrieves DB port from environment variable with default fallback to 3306
  
- **Eliminated code duplication**: Replaced inline password file reading and port hardcoding across multiple files with calls to the new helper functions in:
  - `src/module/table/table.game.php` (constructor and undo operations)
  - `src/module/tablemanager/tablemanager.php` (database connection)

- **Added port configuration**: 
  - Database port is now configurable via `DB_PORT` environment variable
  - Updated all `mysqli` constructor calls to include the port parameter
  - Updated `mysqldump` and `mysql` CLI commands to include `--port` flag

- **Docker configuration**: 
  - Added `DB_PORT=3306` environment variable to Dockerfile
  - Added example database password file creation for testing
  - Added missing game module copy to Docker image

## Implementation Details
The refactoring centralizes database configuration logic, making it easier to maintain and modify connection parameters in the future. The helper functions provide sensible defaults while allowing environment-based overrides, supporting both direct environment variables and file-based secrets (useful for Docker/Kubernetes deployments).

https://claude.ai/code/session_015uoCNCFeXerJTX3KDbCkdo