### PR TITLE
Enable automatic image builds on main branch pushes

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,6 +1,9 @@
 name: Build and push image
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to automatically trigger image builds when code is pushed to the main branch, in addition to manual workflow dispatch triggers.

## Key Changes
- Added `push` event trigger to the build-and-push workflow
- Configured the trigger to only activate on pushes to the `main` branch
- Maintains existing `workflow_dispatch` capability for manual triggering

## Details
This change enables continuous integration by automatically building and pushing container images whenever changes are merged to the main branch, while preserving the ability to manually trigger builds when needed.

https://claude.ai/code/session_01EuD5xZEyFXRisV5ETFYxnD