### PR TITLE
Update database password secret path from /run/secrets to /etc/secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,9 +101,9 @@ ENV PATH="$PATH:/vendor/bin"
 ENV DB_HOST=db
 ENV DB_PORT=3306
 ENV DB_USER=root
-ENV DB_PASSWORD_FILE_PATH=/run/secrets/db-password
+ENV DB_PASSWORD_FILE_PATH=/etc/secrets/db-password
 
-RUN mkdir -p /run/secrets && echo -n 'example-pass' > /run/secrets/db-password
+RUN mkdir -p /etc/secrets && echo -n 'example-pass' > /etc/secrets/db-password
 
 COPY ./src/localarena_config.inc.php /src/localarena/localarena_config.inc.php
 COPY ./src/module /src/localarena/module

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ ENV DB_PORT=3306
 ENV DB_USER=root
 ENV DB_PASSWORD_FILE_PATH=/run/secrets/db-password
 
-RUN echo -n 'example-pass' > /run/secrets/db-password
+RUN mkdir -p /run/secrets && echo -n 'example-pass' > /run/secrets/db-password
 
 COPY ./src/localarena_config.inc.php /src/localarena/localarena_config.inc.php
 COPY ./src/module /src/localarena/module


### PR DESCRIPTION
## Summary
Updated the database password secret file path configuration to use `/etc/secrets` instead of `/run/secrets`, and ensured the directory is created during the Docker build process.

## Key Changes
- Changed `DB_PASSWORD_FILE_PATH` environment variable from `/run/secrets/db-password` to `/etc/secrets/db-password`
- Updated the RUN command to create the `/etc/secrets` directory before writing the password file
- Modified the echo command to use the new `/etc/secrets/db-password` path

## Implementation Details
The change ensures that the secrets directory exists before attempting to write the password file to it, preventing potential "directory not found" errors during container initialization. This approach provides better compatibility with standard Docker secret management practices and filesystem conventions.

https://claude.ai/code/session_019sTw1T1BPspXdzh6aZyo5u