### PR TITLE
Enable multi-platform Docker builds for amd64 and arm64

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -28,6 +28,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -37,6 +40,7 @@ jobs:
           context: .
           target: testenv
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
This PR enables multi-platform Docker image builds to support both AMD64 and ARM64 architectures in the CI/CD pipeline.

## Key Changes
- Added QEMU setup step (`docker/setup-qemu-action@v3`) to enable emulation of non-native architectures during Docker builds
- Added `platforms: linux/amd64,linux/arm64` configuration to the Docker Buildx build step to generate images for both x86-64 and ARM64 architectures

## Implementation Details
The changes leverage Docker Buildx's native multi-platform build capabilities. QEMU is set up first to provide the necessary emulation layer, allowing the build process to create optimized images for both AMD64 and ARM64 platforms in a single build operation. Both platform images are tagged with the same registry reference and pushed simultaneously.

https://claude.ai/code/session_01KTrajt86kKXN1pvr15WiY3