### PR TITLE
Fix undoSavepoint() deadlock; add db_undo_support guard + tests

### DIFF
--- a/src/game/localarenanoop/gameinfos.inc.php
+++ b/src/game/localarenanoop/gameinfos.inc.php
@@ -8,4 +8,5 @@ $gameinfos = [
         'ffa500',
         '773300',
     ],
+    'db_undo_support' => true,
 ];

--- a/src/module/table/table.game.php
+++ b/src/module/table/table.game.php
@@ -1480,14 +1480,18 @@
    */
   public function undoSavepoint(): void
   {
+      $this->requireUndoSupport();
       $undo_file = $this->getUndoFilePath();
       $servername = getenv('DB_HOST');
       $username = getenv('DB_USER');
       $password = localarena_db_password();
       $port = localarena_db_port();
 
+      // --single-transaction: snapshot via InnoDB MVCC instead of LOCK TABLES,
+      // which would deadlock against the PHP request's open mysqli connection.
       $cmd = "mysqldump --user={$username} --password={$password} " .
-          "--host={$servername} --port={$port} --skip-ssl {$this->dbname} --result-file={$undo_file} 2>&1";
+          "--host={$servername} --port={$port} --skip-ssl --single-transaction --skip-lock-tables " .
+          "{$this->dbname} --result-file={$undo_file} 2>&1";
       exec($cmd, $output, $result_code);
   }
 
@@ -1496,6 +1500,7 @@
    */
   public function undoRestorePoint(): void
   {
+      $this->requireUndoSupport();
       $undo_file = $this->getUndoFilePath();
       if (file_exists($undo_file)) {
           $servername = getenv('DB_HOST');
@@ -1506,6 +1511,16 @@
           $cmd = "mysql --user={$username} --password={$password} " .
               "--host={$servername} --port={$port} --skip-ssl {$this->dbname} < {$undo_file} 2>&1";
           exec($cmd, $output, $result_code);
+      }
+  }
+
+  private function requireUndoSupport(): void
+  {
+      if (empty($this->game_infos['db_undo_support'])) {
+          throw new \Exception(
+              "Undo is not enabled for this game. " .
+              "Set 'db_undo_support' => true in gameinfos.inc.php to enable undo functionality."
+          );
       }
   }
 

--- a/tests/UndoTest.php
+++ b/tests/UndoTest.php
@@ -104,4 +104,30 @@ class UndoTest extends IntegrationTestCase
             "SELECT player_score FROM player WHERE player_id = " . $playerId
         );
     }
+
+    /**
+     * Test that undoSavepoint() throws when db_undo_support is not enabled.
+     */
+    public function testUndoSavepointRequiresDbUndoSupport(): void
+    {
+        $this->table()->game_infos['db_undo_support'] = false;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Undo is not enabled for this game");
+
+        $this->table()->undoSavepoint();
+    }
+
+    /**
+     * Test that undoRestorePoint() throws when db_undo_support is not enabled.
+     */
+    public function testUndoRestorePointRequiresDbUndoSupport(): void
+    {
+        $this->table()->game_infos['db_undo_support'] = false;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage("Undo is not enabled for this game");
+
+        $this->table()->undoRestorePoint();
+    }
 }


### PR DESCRIPTION
## Summary

Folds in three related additions to the undo functionality introduced by 66abee58, packaged as one fixup commit:

- **`requireUndoSupport()` guard** in `table.game.php` — throws when the game's `gameinfos.inc.php` does not set `'db_undo_support' => true`. Wired into both `undoSavepoint()` and `undoRestorePoint()`.
- **`'db_undo_support' => true`** added to `src/game/localarenanoop/gameinfos.inc.php` so LocalArena's own `UndoTest` suite can exercise undo against the dummy game.
- **Two new `UndoTest` cases** verifying that `undoSavepoint()` and `undoRestorePoint()` throw with `"Undo is not enabled for this game"` when the flag is off.

It also fixes a deadlock in `undoSavepoint()`'s `mysqldump` invocation:

The default `mysqldump` issues `LOCK TABLES ... READ` for snapshot consistency. Because `undoSavepoint()` is called from a PHP request that keeps its own mysqli connection open, that connection holds metadata locks on the same tables — so `mysqldump`'s lock request waits forever (`Waiting for table metadata lock` in `SHOW PROCESSLIST`). Adding `--single-transaction --skip-lock-tables` switches to InnoDB MVCC for snapshot consistency, which is safe for the all-InnoDB schema BGA/LocalArena uses and unblocks the dump.

Without the mysqldump fix, the three pre-existing `UndoTest` cases (added in 9d9bfd78) hang indefinitely instead of running — the failure mode you'd otherwise hit the moment you turned on `db_undo_support` for the test scaffold.

## Test plan

- [ ] LocalArena's own `UndoTest` suite runs to completion (no hangs).
- [ ] Verified downstream: full bga-theloop server test suite (433 tests, 133,639 assertions) passes against a testenv built from this branch, with bga-theloop's new per-turn `undoSavepoint()` call in `stAgentAction`.