### PR TITLE
Reject undoSavepoint/undoRestorePoint from incompatible state types

### DIFF
--- a/src/module/table/table.game.php
+++ b/src/module/table/table.game.php
@@ -1503,6 +1503,7 @@
           // Disabled mode (default in tests): no-op so unrelated tests don't pay the mysqldump cost.
           return;
       }
+      $this->requireUndoCompatibleState('undoSavepoint');
       $undo_file = $this->getUndoFilePath();
       $servername = getenv('DB_HOST');
       $username = getenv('DB_USER');
@@ -1533,6 +1534,7 @@
               '$this->table()->setUndoSavepointsEnabled(true) during setup.'
           );
       }
+      $this->requireUndoCompatibleState('undoRestorePoint');
       $undo_file = $this->getUndoFilePath();
       if (file_exists($undo_file)) {
           $servername = getenv('DB_HOST');
@@ -1543,6 +1545,33 @@
           $cmd = "mysql --user={$username} --password={$password} " .
               "--host={$servername} --port={$port} --skip-ssl {$this->dbname} < {$undo_file} 2>&1";
           exec($cmd, $output, $result_code);
+      }
+  }
+
+  /**
+   * Reject undoSavepoint() / undoRestorePoint() from state types that real BGA forbids.  The well-known
+   * "UNDO cannot be used for multiple active players game states" message is what production throws when undo
+   * is attempted from a `multipleactiveplayer` state -- mirroring it here means test suites catch that class
+   * of bug locally, instead of finding out at deploy time.
+   *
+   * BGA allows undo from `activeplayer` and `game` states; this method handles those by no-op-returning, and
+   * fails loudly for anything else so unrecognised contexts surface during tests.
+   */
+  private function requireUndoCompatibleState(string $caller): void
+  {
+      $stateType = $this->gamestate->state()['type'] ?? null;
+      switch ($stateType) {
+          case 'activeplayer':
+          case 'game':
+              return;
+          case 'multipleactiveplayer':
+              throw new \BgaVisibleSystemException(
+                  'UNDO cannot be used for multiple active players game states'
+              );
+          default:
+              throw new \BgaVisibleSystemException(
+                  $caller . '() called from unexpected state type: ' . var_export($stateType, true)
+              );
       }
   }
 


### PR DESCRIPTION
## Summary

Real BGA refuses \`undoSavepoint()\` / \`undoRestorePoint()\` with \"UNDO cannot be used for multiple active players game states\" when called from a \`multipleactiveplayer\` state. LocalArena's mock previously didn't enforce that, so games could pass their full test suite with savepoints being taken from contexts real BGA rejects -- only to fail at deploy. That just bit wardcanyon/bga-theloop#44 (https://github.com/wardcanyon/bga-theloop/commit/a1676a8 references the production error).

Add \`requireUndoCompatibleState()\` invoked at the top of both \`undoSavepoint()\` and \`undoRestorePoint()\`. Policy:

| State type             | Behavior                                          |
|------------------------|---------------------------------------------------|
| \`activeplayer\`         | proceed (BGA allows)                              |
| \`game\`                 | proceed (BGA allows)                              |
| \`multipleactiveplayer\` | throw the well-known BGA error message            |
| anything else / null   | throw, naming the unexpected type so tests surface mis-use |

The wording for the \`multipleactiveplayer\` branch is verbatim BGA's string so downstream test assertions can match on it.

## Caveat

I'm reasonably sure \`activeplayer\` and \`game\` are both legal in BGA based on docs and observed behavior, but if anyone has a counter-example (BGA rejecting \`game\`-state savepoints) we should tighten the policy here.

## Test plan

- [ ] Existing \`UndoTest\` suite passes (the three positive tests run from an \`activeplayer\` state after game setup; the two negative \`requireDbUndoSupport\` tests fail in \`requireUndoSupport()\` before reaching the new check).
- [ ] Downstream: \`bga-theloop\` \`a1676a8\` (Defer undoSavepoint() to the next activeplayer-state entry) defers the actual primitive call to \`stAgentAction\`'s entry hook -- with this PR's mock in place, that pattern is verifiable in CI.