### PR TITLE
Disable undo savepoints by default in tests; opt-in via TableParams

### DIFF
--- a/src/module/table/table.game.php
+++ b/src/module/table/table.game.php
@@ -1475,12 +1475,34 @@
 
   // ==================== Undo Support ====================
 
+  // Whether undoSavepoint() / undoRestorePoint() are active.  Defaults to false so the LocalArena test harness
+  // doesn't pay a mysqldump cost on every savepoint call -- in practice, most tests transit through state hooks
+  // that take savepoints but never exercise undo themselves.  Tests that DO exercise undo opt in by calling
+  // setUndoSavepointsEnabled(true) during setup.  This flag has no effect in real BGA production, which runs
+  // through its own Table class rather than this LocalArena mock.
+  protected bool $undoSavepointsEnabled_ = false;
+
+  /**
+   * Turn savepoint creation and restoration on or off.  When off, undoSavepoint() is a free no-op and
+   * undoRestorePoint() throws (so a test that attempts to exercise undo without opting in fails loudly).
+   * Tests that genuinely exercise undo should call setUndoSavepointsEnabled(true) before the savepoint of
+   * interest is taken.
+   */
+  public function setUndoSavepointsEnabled(bool $enabled): void
+  {
+      $this->undoSavepointsEnabled_ = $enabled;
+  }
+
   /**
    * Save the whole game situation inside an "Undo save point".
    */
   public function undoSavepoint(): void
   {
       $this->requireUndoSupport();
+      if (!$this->undoSavepointsEnabled_) {
+          // Disabled mode (default in tests): no-op so unrelated tests don't pay the mysqldump cost.
+          return;
+      }
       $undo_file = $this->getUndoFilePath();
       $servername = getenv('DB_HOST');
       $username = getenv('DB_USER');
@@ -1501,6 +1523,16 @@
   public function undoRestorePoint(): void
   {
       $this->requireUndoSupport();
+      if (!$this->undoSavepointsEnabled_) {
+          // Disabled mode (default in tests): a test that reaches here without enabling savepoints first is
+          // almost certainly trying to exercise undo without realising the harness has stripped it.  Fail
+          // loudly rather than silently no-op-ing -- a silent no-op would let the test pass while producing
+          // results inconsistent with production.
+          throw new \BgaVisibleSystemException(
+              'undoRestorePoint(): savepoints are disabled.  Tests that exercise undo must call ' .
+              '$this->table()->setUndoSavepointsEnabled(true) during setup.'
+          );
+      }
       $undo_file = $this->getUndoFilePath();
       if (file_exists($undo_file)) {
           $servername = getenv('DB_HOST');

--- a/src/module/tablemanager/TableParams.php
+++ b/src/module/tablemanager/TableParams.php
@@ -21,4 +21,10 @@ class TableParams
     //
     // This mechanism is intended only for PHPUnit tests.
     public $table_class = null;
+
+    // Iff true, undoSavepoint() / undoRestorePoint() are active on the table from creation.  Defaults to false
+    // so the typical test (which transits through state hooks that take savepoints but never exercises undo
+    // itself) pays no mysqldump cost.  Tests that exercise undo opt in by setting this to true in their
+    // defaultTableParams() override -- see UndoTest for an example.
+    public bool $enable_undo_savepoints = false;
 }

--- a/src/module/tablemanager/tablemanager.php
+++ b/src/module/tablemanager/tablemanager.php
@@ -155,6 +155,10 @@ class TableManager
         $game->localarenaApplySchema(explode('\n',$params->schema_changes));
     }
 
+    if ($params->enable_undo_savepoints) {
+        $game->setUndoSavepointsEnabled(true);
+    }
+
     return $game;
   }
 }

--- a/tests/UndoTest.php
+++ b/tests/UndoTest.php
@@ -11,6 +11,16 @@ class UndoTest extends IntegrationTestCase
 {
     const LOCALARENA_GAME_NAME = 'localarenanoop';
 
+    protected function defaultTableParams(): \LocalArena\TableParams
+    {
+        // Opt in to real savepoints for this suite; the default ("disabled") would cause undoSavepoint() to
+        // no-op and undoRestorePoint() to throw, which is correct for tests that don't exercise undo but is
+        // not what this suite is for.
+        $params = parent::defaultTableParams();
+        $params->enable_undo_savepoints = true;
+        return $params;
+    }
+
     /**
      * Test that undoSavepoint() and undoRestorePoint() correctly save and restore database state.
      */


### PR DESCRIPTION
## Summary

Most LocalArena tests transit through downstream game state hooks that take savepoints (\`undoSavepoint()\`) but never actually exercise undo. Every savepoint call costs a \`mysqldump\`; multiplied across hundreds of tests it's measurable wasted work.

Switch the default: \`Table::\$undoSavepointsEnabled_\` defaults to \`false\` so that

- \`undoSavepoint()\` becomes a free no-op, and
- \`undoRestorePoint()\` throws a clear \"savepoints are disabled, opt in if your test exercises undo\" exception (silent no-op would let a test green-pass while producing results inconsistent with production).

Tests that genuinely exercise undo opt in via the new \`TableParams::\$enable_undo_savepoints\` field, applied by \`TableManager::createTable()\` after schema load. \`UndoTest\` is updated to use a \`defaultTableParams()\` override -- the canonical pattern downstream test suites can copy:

\`\`\`php
protected function defaultTableParams(): \\LocalArena\\TableParams
{
    \$params = parent::defaultTableParams();
    \$params->enable_undo_savepoints = true;
    return \$params;
}
\`\`\`

## Test plan

- [ ] Existing \`UndoTest\` cases pass with the opt-in in place (they exercise real savepoints).
- [ ] Downstream test suites that don't opt in see no behavioral change beyond \`undoSavepoint()\` becoming an instant no-op -- in practice this means faster tests.

## No effect on production

LocalArena's \`Table\` class isn't loaded in real BGA; this flag only matters for the test mock.