### PR TITLE
Fix current-state global staleness during in-request cascades

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,22 @@
 
 The PHPUnit integration tests require Docker: a `testenv` image plus a
 running MySQL `db` service on the `localarena_default` network (see
-`Gruntfile.cjs`'s `shell:test` task and `compose.yaml`). In this remote
-execution environment the Docker daemon and image registry are **not**
-reliably available (image pulls are blocked by the network policy), so
-the suite generally **cannot be run locally here**.
+`Gruntfile.cjs`'s `shell:test` task and `compose.yaml`). Locally, the
+suite is normally run with `grunt test` (which builds the `testenv`
+image and runs `phpunit` against `tests/phpunit.xml`).
 
-To verify changes, **do not** rely on running the tests in the sandbox.
+### Claude Code Remote (web) sessions
+
+The guidance below applies **only** when running in a Claude Code Remote
+execution environment (e.g. a Claude Code on the web session), where the
+Docker daemon and image registry are **not** reliably available (image
+pulls are blocked by the network policy), so the suite generally
+**cannot be run in the sandbox**.
+
+In that case, **do not** rely on running the tests in the sandbox.
 Instead, push the branch, wait for a PR to be opened, and examine the
 **CI** state for the test results. Investigate and address CI failures
 from there.
 
-For reference, the suite is normally run with `grunt test` (which builds
-the `testenv` image and runs `phpunit` against `tests/phpunit.xml`).
+If you are running locally (not in a remote/web session) with a working
+Docker setup, just run the suite directly with `grunt test`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# Notes for Claude (and other agents)
+
+## Running the test suite
+
+The PHPUnit integration tests require Docker: a `testenv` image plus a
+running MySQL `db` service on the `localarena_default` network (see
+`Gruntfile.cjs`'s `shell:test` task and `compose.yaml`). In this remote
+execution environment the Docker daemon and image registry are **not**
+reliably available (image pulls are blocked by the network policy), so
+the suite generally **cannot be run locally here**.
+
+To verify changes, **do not** rely on running the tests in the sandbox.
+Instead, push the branch, wait for a PR to be opened, and examine the
+**CI** state for the test results. Investigate and address CI failures
+from there.
+
+For reference, the suite is normally run with `grunt test` (which builds
+the `testenv` image and runs `phpunit` against `tests/phpunit.xml`).

--- a/src/game/localarenanoop/localarenanoop.action.php
+++ b/src/game/localarenanoop/localarenanoop.action.php
@@ -13,4 +13,17 @@ class action_localarenanoop extends APP_GameAction
             self::trace("Complete reinitialization of board game");
         }
     }
+
+    // LocalArena test-support action: drive an arbitrary named
+    // transition from the current state, within a real request (so the
+    // request-boundary semantics of the current-state global are
+    // exercised).  Framework tests use this to trigger an in-request
+    // state cascade; real games never expose anything like it.
+    public function actTestTransition()
+    {
+        self::setAjaxMode();
+        $transition = self::getArg("transition", AT_alphanum_dash, /*required=*/ true);
+        $this->game->gamestate->nextState($transition);
+        self::ajaxResponse();
+    }
 }

--- a/src/module/table/GameState.php
+++ b/src/module/table/GameState.php
@@ -183,7 +183,15 @@ class GameState
       );
     }
     $newStateId = $state['transitions'][$transition];
-    $this->game->setGameStateValue('currentState', $newStateId);
+
+    // Advance only the in-memory "live" state.  We deliberately do NOT
+    // write the persisted current-state global here: real BGA leaves
+    // that global pinned at the request's entry state for the whole
+    // synchronous cascade and only advances it at the request
+    // boundary.  LocalArena replicates that -- `Table::saveState()`
+    // flushes the live state into the global once the action parks.
+    // See `Table::$liveStateId_` and `Table::flushCurrentStateGlobal()`.
+    $this->game->setLiveStateId($newStateId);
 
     $this->log(
       'From state "' .
@@ -199,8 +207,19 @@ class GameState
   }
 
   /**
-   *Get an associative array of current game state attributes, see Your game state machine: states.inc.php for state attributes.
+   * Get an associative array of current game state attributes, see Your game state machine: states.inc.php for state attributes.
    * $state=$this->gamestate->state(); if( $state['name'] == 'myGameState' ) {...}
+   *
+   * This reflects the *live* in-memory state machine: it is updated
+   * immediately by `nextState()`, so during an in-request cascade
+   * through several "game"-type states it always names the state
+   * currently being processed.  This is one of the two ways game code
+   * can ask "what state am I in?"; the other is reading the
+   * current-state global via `getGameStateValue()`, which -- matching
+   * real BGA -- stays pinned at the request's entry state until the
+   * request boundary.  See `Table::getCurrentStateId()` and
+   * `Table::$liveStateId_`.
+   *
    * @return array
    */
   public function state()
@@ -210,10 +229,14 @@ class GameState
   }
 
     /**
-      @return int
-    */
+     * The id of the *live* state (see `state()`).  Updated immediately
+     * by every `nextState()` transition.  NOT the same as
+     * `getGameStateValue('currentState')` during a cascade, which lags.
+     *
+     * @return int
+     */
     public function state_id()
     {
-        return $this->game->getGameStateValue('currentState');
+        return $this->game->getLiveStateId();
     }
 }

--- a/src/module/table/table.game.php
+++ b/src/module/table/table.game.php
@@ -399,6 +399,30 @@
 
      public int $localarena_table_id;
 
+   // The in-memory "live" id of the framework's game-state machine.
+   //
+   // This is the LocalArena equivalent of BGA's in-memory current
+   // state: it advances *immediately* on every `nextState()`
+   // transition, so it stays correct (live) as a single request
+   // cascades synchronously through a chain of "game"-type states.
+   // `$this->gamestate->state()` / `state_id()` and
+   // `getCurrentStateId()` all read this value.
+   //
+   // It is deliberately decoupled from the *persisted* current-state
+   // global (global #1, label 'currentState'): see
+   // `flushCurrentStateGlobal()` and `getGameStateValue()` for the
+   // rationale.  In short, real BGA leaves the current-state global
+   // pinned at the state the request *entered* in for the duration of
+   // an in-request cascade and only advances it at the request
+   // boundary, whereas the in-memory state is live.  We replicate that
+   // divergence so that game code reading the current-state global
+   // mid-cascade behaves the same under LocalArena as in production.
+   //
+   // `null` means "not yet loaded during this request"; it is lazily
+   // initialized from the persisted global (the previous request's
+   // parked state) by `getLiveStateId()`.
+   private ?int $liveStateId_ = null;
+
    function __construct()
    {
      parent::__construct();
@@ -944,9 +968,84 @@
      return false;
    }
 
+   // Returns the *live* id of the framework's game-state machine --
+   // i.e. the state that has most recently been entered, updated
+   // immediately by every `nextState()` transition (including
+   // intra-request cascades).
+   //
+   // IMPORTANT: This is NOT the same as reading the current-state
+   // global via `getGameStateValue('currentState')`.  The two diverge
+   // while a single request synchronously cascades through several
+   // "game"-type states:
+   //
+   //   - `getCurrentStateId()` (and `gamestate->state()` /
+   //     `state_id()`) are LIVE -- they track the in-memory machine
+   //     and change on each `nextState()`.
+   //
+   //   - `getGameStateValue('currentState')` is STALE -- it stays
+   //     pinned at the state the request entered in until the request
+   //     boundary (see `flushCurrentStateGlobal()`).
+   //
+   // Framework/harness code that asks "what state is the machine in
+   // right now?" wants the live value, so it uses this method.
    function getCurrentStateId(): int
    {
-     return $this->getGameStateValue('currentState');
+     return $this->getLiveStateId();
+   }
+
+   // Returns the live current-state id, lazily initializing it from
+   // the persisted current-state global (global #1) the first time it
+   // is needed in a request.  See the `$liveStateId_` doc comment.
+   function getLiveStateId(): int
+   {
+     if ($this->liveStateId_ === null) {
+       $this->liveStateId_ = intval(
+         $this->getUniqueValueFromDB(
+           'select global_value from global where global_id = ' . $this->gameStateLabels['currentState']
+         )
+       );
+     }
+     return $this->liveStateId_;
+   }
+
+   // Advances the in-memory live current state.  Crucially, this does
+   // NOT write the persisted current-state global; that global is only
+   // updated at the request boundary by `flushCurrentStateGlobal()`.
+   // Called by `GameState::nextState()`.
+   function setLiveStateId(int $state_id): void
+   {
+     $this->liveStateId_ = $state_id;
+   }
+
+   // Persists the in-memory live current state into the current-state
+   // global (global #1, label 'currentState').
+   //
+   // This is the mechanism that reproduces real BGA's staleness rule.
+   // During an in-request cascade, `nextState()` advances only the
+   // in-memory `$liveStateId_` and leaves the global untouched, so any
+   // game code that reads the current-state global via
+   // `getGameStateValue()` mid-cascade sees the state the request
+   // *entered* in -- exactly as it would on BGA Studio.  Only here, at
+   // the request boundary (the game has finished processing the action
+   // and parked in a state awaiting player input), do we advance the
+   // global to the live value, so the next request and the persisted
+   // game state see the parked state.
+   //
+   // Invoked from `saveState()`, which is LocalArena's single
+   // persistence chokepoint at the end of each request (both
+   // `initTable()` setup and `doAction()` player actions).
+   function flushCurrentStateGlobal(): void
+   {
+     if ($this->liveStateId_ === null) {
+       // Nothing advanced the live state this request; the global is
+       // already correct.
+       return;
+     }
+     $keyint = $this->gameStateLabels['currentState'];
+     $this->DbQuery(
+       "INSERT INTO global (global_id, global_value) values({$keyint},{$this->liveStateId_}) " .
+         "ON DUPLICATE KEY UPDATE global_value={$this->liveStateId_}"
+     );
    }
 
      function localarenaApplySchema($lines) {
@@ -1081,6 +1180,27 @@
    {
    }
 
+     // Reads a game-state global (a BGA "global variable") by label.
+     //
+     // For ordinary game globals this is a straightforward read of the
+     // `global` table.
+     //
+     // Note the special behavior for the framework's reserved
+     // current-state global (global #1, label 'currentState', or any
+     // game-defined label that maps to that id, e.g. BGA's
+     // `BGA_GAMESTATE_CURRENT_STATE`).  This is the SECOND of the two
+     // ways game code can ask "what state am I in?" -- and, matching
+     // real BGA, it is deliberately STALE during an in-request cascade.
+     // `nextState()` does not write the global; it is only advanced at
+     // the request boundary (`flushCurrentStateGlobal()`).  So while a
+     // single action synchronously cascades through several
+     // "game"-type states, this returns the state the request *entered*
+     // in, even though `getCurrentStateId()` /
+     // `gamestate->state_id()` (the live, in-memory state -- the FIRST
+     // way) have already moved on.  Game logic that branches on the
+     // current-state global mid-cascade therefore behaves the same here
+     // as in production.
+     //
      // XXX: $default is ignored.
    function getGameStateValue($key, $default=0)
    {
@@ -1238,6 +1358,13 @@
 
    function saveState()
    {
+     // Request boundary: advance the persisted current-state global to
+     // the live state now that the action's synchronous cascade has
+     // finished and the game has parked.  Until this point the global
+     // deliberately lagged (see `flushCurrentStateGlobal()`), so that
+     // game code reading it mid-cascade matched real BGA's staleness.
+     $this->flushCurrentStateGlobal();
+
      $moveId = $this->getGameStateValue('moveId');
      $players = $this->loadPlayersBasicInfos();
      $prevCurrentPlayerId = $this->currentPlayer;
@@ -1545,6 +1672,12 @@
           $cmd = "mysql --user={$username} --password={$password} " .
               "--host={$servername} --port={$port} --skip-ssl {$this->dbname} < {$undo_file} 2>&1";
           exec($cmd, $output, $result_code);
+
+          // The restore overwrote the entire database, including the
+          // persisted current-state global.  Drop the in-memory live
+          // state so the next read re-derives it from the restored
+          // global rather than from a now-stale cached value.
+          $this->liveStateId_ = null;
       }
   }
 

--- a/tests/CurrentStateGlobalCascadeTest.php
+++ b/tests/CurrentStateGlobalCascadeTest.php
@@ -1,0 +1,304 @@
+<?php declare(strict_types=1);
+
+namespace LocalArena\Test;
+
+require_once __DIR__ . '/../module/test/IntegrationTestCase.php';
+
+// We extend the bundled "localarenanoop" harness game, so load its
+// class.  When a test supplies a `table_class`, TableManager::getTable()
+// instantiates that class directly and does NOT require the game's
+// .game.php file, so we must require it ourselves before subclassing.
+require_once LOCALARENA_GAME_PATH . 'localarenanoop/localarenanoop.game.php';
+
+/**
+ * Regression test for the LocalArena <-> real-BGA divergence in the
+ * framework's reserved "current state" global during an in-request
+ * state cascade.
+ *
+ * There are two ways game code can ask "what state am I in?":
+ *
+ *   1. The live, in-memory state machine -- `gamestate->state()` /
+ *      `gamestate->state_id()`, and the framework helper
+ *      `getCurrentStateId()`.  These advance *immediately* on every
+ *      `nextState()` transition.
+ *
+ *   2. The persisted current-state global -- `getGameStateValue()` for
+ *      the reserved current-state global (global #1 / label
+ *      'currentState', or any game label aliased to it, e.g. BGA's
+ *      `BGA_GAMESTATE_CURRENT_STATE`).
+ *
+ * On real BGA these DIVERGE while a single request synchronously
+ * cascades through several "game"-type states: (1) is live, but (2)
+ * stays pinned at the state the request *entered* in until the request
+ * boundary.  Historically LocalArena kept the two in lockstep, masking
+ * a class of production bugs.  This test pins the corrected behavior.
+ */
+class CurrentStateGlobalCascadeTest extends IntegrationTestCase
+{
+    const LOCALARENA_GAME_NAME = 'localarenanoop';
+
+    // State ids used by the cascade machine installed below.
+    const ST_INPUT = 2;        // entry / input state (activeplayer)
+    const ST_CASCADE_A = 10;   // game-type
+    const ST_CASCADE_B = 11;   // game-type
+    const ST_CASCADE_C = 12;   // game-type
+    const ST_SECOND_INPUT = 13; // where the cascade parks (activeplayer)
+
+    protected function defaultTableParams(): \LocalArena\TableParams
+    {
+        $params = parent::defaultTableParams();
+        // Reuse all of localarenanoop's files (states/gameinfos/dbmodel/
+        // action class etc.), but instantiate our cascade-aware
+        // subclass instead of the plain game class.
+        $params->table_class = CascadeStateTestGame::class;
+        return $params;
+    }
+
+    private function game(): CascadeStateTestGame
+    {
+        return $this->table();
+    }
+
+    /**
+     * The core LocalArena-level assertion: during a multi-game-state
+     * cascade triggered by one action, the current-state global stays
+     * equal to the entry state while the live state id advances.
+     */
+    public function testCurrentStateGlobalLagsLiveStateDuringCascade(): void
+    {
+        $game = $this->game();
+
+        // After setup the game has parked at the input state, and the
+        // live state and the persisted global agree (no cascade in
+        // flight).
+        $this->assertEquals(self::ST_INPUT, $game->getCurrentStateId());
+        $this->assertEquals(self::ST_INPUT, intval($game->getGameStateValue('currentState')));
+
+        // One player action drives the whole cascade:
+        //   ST_INPUT -> ST_CASCADE_A -> ST_CASCADE_B -> ST_CASCADE_C
+        //            -> ST_SECOND_INPUT (parks).
+        // The action carries no active-player dependency, so any
+        // participant may submit it.
+        $this->playerByIndex(0)->act('actTestTransition', ['transition' => 'go']);
+
+        // Each game-type state recorded both readings as it was entered.
+        $recorded = $game->recorded;
+        $this->assertCount(3, $recorded, 'Expected one record per game-type state in the cascade.');
+
+        $expectedLive = [self::ST_CASCADE_A, self::ST_CASCADE_B, self::ST_CASCADE_C];
+        foreach ($recorded as $i => $step) {
+            // (1) The live, in-memory state advances on each nextState().
+            $this->assertEquals(
+                $expectedLive[$i],
+                $step['live_state_id'],
+                "getCurrentStateId() should be live at cascade step {$i} ({$step['name']})."
+            );
+            $this->assertEquals(
+                $expectedLive[$i],
+                $step['live_state_id_via_gamestate'],
+                "gamestate->state_id() should be live at cascade step {$i} ({$step['name']})."
+            );
+            $this->assertEquals(
+                $step['name'],
+                $step['live_state_name'],
+                "gamestate->state()['name'] should be live at cascade step {$i}."
+            );
+
+            // (2) The current-state global LAGS: pinned at the entry
+            // state for the entire cascade -- this is the real-BGA
+            // staleness LocalArena must replicate.
+            $this->assertEquals(
+                self::ST_INPUT,
+                $step['current_state_global'],
+                "getGameStateValue('currentState') should stay pinned at the entry state during the cascade " .
+                    "(step {$i}, {$step['name']})."
+            );
+            $this->assertEquals(
+                self::ST_INPUT,
+                $step['current_state_global_via_alias'],
+                "A game label aliased to the current-state global should lag identically (step {$i})."
+            );
+
+            // The whole point of the divergence: the two disagree
+            // mid-cascade.
+            $this->assertNotEquals(
+                $step['current_state_global'],
+                $step['live_state_id'],
+                "The live state and the current-state global must diverge mid-cascade (step {$i})."
+            );
+        }
+
+        // At the request boundary the global catches up to the parked
+        // state, and the two are back in agreement.
+        $this->assertEquals(self::ST_SECOND_INPUT, $game->getCurrentStateId());
+        $this->assertEquals(
+            self::ST_SECOND_INPUT,
+            intval($game->getGameStateValue('currentState')),
+            'After the request, the current-state global should equal the parked state.'
+        );
+    }
+
+    /**
+     * Companion check on the "live" side in isolation: outside of any
+     * cascade, both ways of reading the current state agree, and
+     * `nextState()` immediately updates the live readings.
+     */
+    public function testLiveStateUpdatesImmediatelyOnNextState(): void
+    {
+        $game = $this->game();
+
+        // Parked at the input state; everything agrees.
+        $this->assertEquals(self::ST_INPUT, $game->gamestate->state_id());
+        $this->assertEquals(self::ST_INPUT, $game->getCurrentStateId());
+        $this->assertEquals(self::ST_INPUT, intval($game->getGameStateValue('currentState')));
+
+        // Drive a single transition directly into another input state
+        // (which has no auto-advancing action, so the machine stops
+        // there).  The live readings move at once...
+        $game->gamestate->nextState('step');
+        $this->assertEquals(self::ST_SECOND_INPUT, $game->gamestate->state_id());
+        $this->assertEquals(self::ST_SECOND_INPUT, $game->getCurrentStateId());
+
+        // ...but the persisted global has NOT been flushed yet, so it
+        // still reports the pre-transition state.
+        $this->assertEquals(
+            self::ST_INPUT,
+            intval($game->getGameStateValue('currentState')),
+            'The current-state global must not advance until the request boundary flush.'
+        );
+
+        // Flushing (what saveState() does at the request boundary)
+        // brings the global into agreement with the live state.
+        $game->flushCurrentStateGlobal();
+        $this->assertEquals(self::ST_SECOND_INPUT, intval($game->getGameStateValue('currentState')));
+    }
+}
+
+/**
+ * A localarenanoop subclass whose only job is to install a state
+ * machine that cascades through several "game"-type states, and to
+ * record -- as each of those states is entered -- both ways of reading
+ * the current state.  Used only by CurrentStateGlobalCascadeTest.
+ */
+class CascadeStateTestGame extends \localarenanoop
+{
+    /**
+     * One entry per game-type state entered during a cascade, each with
+     * the live state readings and the (lagging) current-state global.
+     *
+     * @var array<int, array<string, mixed>>
+     */
+    public array $recorded = [];
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        // Alias a game-defined label onto the reserved current-state
+        // global (global #1), mirroring how a real game might map
+        // `'bgaCurrentState' => BGA_GAMESTATE_CURRENT_STATE`.  Reads via
+        // this label must lag identically to reads via 'currentState'.
+        $this->initGameStateLabels(['myCurrentStateLabel' => 1]);
+
+        // Replace the trivial noop machine with one that cascades.
+        $this->gamestate = new \GameState($this, self::cascadeMachineStates());
+    }
+
+    private static function cascadeMachineStates(): array
+    {
+        return [
+            // Initial state; base Table::stGameSetup() runs here and
+            // transitions to the input state.
+            1 => [
+                'name' => 'gameSetup',
+                'description' => '',
+                'type' => 'manager',
+                'action' => 'stGameSetup',
+                'transitions' => ['' => CurrentStateGlobalCascadeTest::ST_INPUT],
+            ],
+
+            // Entry / input state: the request enters here, and the
+            // current-state global stays pinned at this id for the whole
+            // cascade triggered from it.
+            CurrentStateGlobalCascadeTest::ST_INPUT => [
+                'name' => 'stInput',
+                'description' => '',
+                'type' => 'activeplayer',
+                'possibleactions' => ['actTestTransition'],
+                'transitions' => [
+                    // Kicks off the multi-state cascade.
+                    'go' => CurrentStateGlobalCascadeTest::ST_CASCADE_A,
+                    // Single hop straight to another input (activeplayer)
+                    // state -- no auto-advancing "game" state in between,
+                    // so the machine stops there.  Used to observe one
+                    // immediate transition in isolation.
+                    'step' => CurrentStateGlobalCascadeTest::ST_SECOND_INPUT,
+                ],
+            ],
+
+            CurrentStateGlobalCascadeTest::ST_CASCADE_A => [
+                'name' => 'stCascadeA',
+                'description' => '',
+                'type' => 'game',
+                'action' => 'stCascadeA',
+                'transitions' => ['next' => CurrentStateGlobalCascadeTest::ST_CASCADE_B],
+            ],
+            CurrentStateGlobalCascadeTest::ST_CASCADE_B => [
+                'name' => 'stCascadeB',
+                'description' => '',
+                'type' => 'game',
+                'action' => 'stCascadeB',
+                'transitions' => ['next' => CurrentStateGlobalCascadeTest::ST_CASCADE_C],
+            ],
+            CurrentStateGlobalCascadeTest::ST_CASCADE_C => [
+                'name' => 'stCascadeC',
+                'description' => '',
+                'type' => 'game',
+                'action' => 'stCascadeC',
+                'transitions' => ['next' => CurrentStateGlobalCascadeTest::ST_SECOND_INPUT],
+            ],
+
+            // Where the cascade parks (awaiting player input again).
+            CurrentStateGlobalCascadeTest::ST_SECOND_INPUT => [
+                'name' => 'stSecondInput',
+                'description' => '',
+                'type' => 'activeplayer',
+                'possibleactions' => [],
+                'transitions' => [],
+            ],
+        ];
+    }
+
+    public function stCascadeA(): void
+    {
+        $this->recordCascadeStep('stCascadeA');
+    }
+
+    public function stCascadeB(): void
+    {
+        $this->recordCascadeStep('stCascadeB');
+    }
+
+    public function stCascadeC(): void
+    {
+        $this->recordCascadeStep('stCascadeC');
+    }
+
+    // Record both ways of reading the current state as this game-type
+    // state is entered, then continue the cascade.
+    private function recordCascadeStep(string $name): void
+    {
+        $this->recorded[] = [
+            'name' => $name,
+            // (1) live, in-memory readings
+            'live_state_id' => $this->getCurrentStateId(),
+            'live_state_id_via_gamestate' => $this->gamestate->state_id(),
+            'live_state_name' => $this->gamestate->state()['name'],
+            // (2) persisted current-state global (should lag)
+            'current_state_global' => intval($this->getGameStateValue('currentState')),
+            'current_state_global_via_alias' => intval($this->getGameStateValue('myCurrentStateLabel')),
+        ];
+
+        $this->gamestate->nextState('next');
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes a divergence between LocalArena and real BGA in how the framework's reserved "current state" global behaves during synchronous in-request state cascades. On BGA, this global stays pinned at the state the request entered in until the request boundary, while the in-memory state machine advances immediately. LocalArena was keeping the two in lockstep, masking a class of production bugs.

## Key Changes

- **Decouple live state from persisted global**: Introduced `$liveStateId_` to track the in-memory state machine separately from the persisted current-state global (global #1). The live state advances immediately on each `nextState()` call, while the global is only updated at request boundaries.

- **Update `getCurrentStateId()` and `GameState::state_id()`**: Changed to read from the live in-memory state (`getLiveStateId()`) instead of the persisted global, ensuring framework code sees the current state during cascades.

- **Add request-boundary flush**: Implemented `flushCurrentStateGlobal()` to persist the live state into the global at the end of each request (called from `saveState()`). This ensures the next request sees the correct parked state while maintaining staleness during the current request's cascade.

- **Update `GameState::nextState()`**: Changed to call `setLiveStateId()` instead of writing the persisted global directly, preserving the staleness semantics.

- **Handle undo/restore**: Clear the cached live state when the database is restored so it re-derives from the restored global.

- **Add comprehensive test**: Created `CurrentStateGlobalCascadeTest` with a custom game class that cascades through multiple "game"-type states and verifies that:
  - The live state advances immediately on each transition
  - The current-state global stays pinned at the entry state during the cascade
  - Both converge again at the request boundary

- **Add test-support action**: Implemented `actTestTransition` in localarenanoop to allow tests to trigger arbitrary state transitions within a real request context.

## Implementation Details

The fix preserves real BGA's behavior where game code reading `getGameStateValue('currentState')` mid-cascade sees the request's entry state, even though `getCurrentStateId()` and `gamestate->state_id()` have moved on. This ensures game logic that branches on the current-state global behaves identically in production and under LocalArena.

https://claude.ai/code/session_019TAkaoqCxPorfk9RuioSrJ