### PR TITLE
Only push Docker image after test suite passes

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,9 +1,15 @@
 name: Build and push image
 
 on:
-  push:
+  # Only build/push after the test suite has run on main. The
+  # `workflow_run` event fires when the referenced workflow completes;
+  # the job-level `if` below ensures we only push when it succeeded.
+  workflow_run:
+    workflows: ["test:server"]
     branches:
       - main
+    types:
+      - completed
   workflow_dispatch:
 
 env:
@@ -14,12 +20,22 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
+    # Run on a manual dispatch, or when the triggering test workflow
+    # succeeded. This skips the push when test:server fails.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+
     permissions:
       contents: read
       packages: write
 
     steps:
+      # Build the exact commit that test:server ran against. On
+      # workflow_dispatch this is empty and checkout uses the dispatched ref.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary

Changes the build-and-push workflow to only push Docker images after the test suite has successfully completed, rather than on every push to main. This prevents pushing broken images when tests fail.

## Key Changes

- **Trigger event**: Changed from `push` to `workflow_run` that listens for the "test:server" workflow to complete
- **Conditional execution**: Added job-level `if` condition to only run when:
  - Manually dispatched via `workflow_dispatch`, OR
  - The triggering test workflow succeeded (`github.event.workflow_run.conclusion == 'success'`)
- **Checkout ref**: Updated checkout step to use the exact commit that the test workflow ran against (`github.event.workflow_run.head_sha`), ensuring consistency between test and build

## Implementation Details

The workflow now uses the `workflow_run` event with `types: [completed]` to trigger after test:server finishes. The conditional logic allows both manual dispatch (for emergency pushes) and automatic pushes only when tests pass. On manual dispatch, the ref is empty and checkout uses the dispatched ref as normal; on workflow_run completion, it explicitly checks out the commit that was tested.

https://claude.ai/code/session_011hFiv64XyKHtd5HavY466B