### PR TITLE
Let a table choose its game options at creation

### DIFF
--- a/src/game/localarenanoop/gameoptions.inc.php
+++ b/src/game/localarenanoop/gameoptions.inc.php
@@ -1,6 +1,37 @@
 <?php
 
+// The no-op game itself ignores its options; they exist so that
+// LocalArena's own tests have a game whose options can be chosen at
+// table creation (see tests/GameOptionsTest.php, which names these ids
+// and values).
+//
+// Option 100's value 3 is deliberately commented out.  That is how a
+// game ships content it has implemented but does not yet want players
+// to select: BGA's lobby offers only the values listed here, while the
+// engine honors the value if it is set.  Reaching such a value from a
+// test is what `TableParams::$allow_unpublished_option_values` is for,
+// so the no-op game needs one to test against.
+//
+// N.B.: No constants here.  This file is `include`d afresh for every
+// table constructed in the process (see `Table::__construct()`), and a
+// test may build several.
 
-$game_options = [];
+$game_options = [
+    100 => [
+        'name' => 'Test option',
+        'values' => [
+            1 => [
+                'name' => 'First',
+            ],
+            2 => [
+                'name' => 'Second',
+            ],
+            // 3 => [
+            //     'name' => 'Third',
+            // ],
+        ],
+        'default' => 1,
+    ],
+];
 
 $game_preferences = [];

--- a/src/module/table/table.game.php
+++ b/src/module/table/table.game.php
@@ -427,6 +427,14 @@
    // legacy data throws during that window (as on BGA).
    private bool $localarena_in_game_setup_ = false;
 
+   // The game-option values this table was created with, and the
+   // option ids permitted to carry an unpublished value; see
+   // `TableParams::$game_options` and
+   // `TableParams::$allow_unpublished_option_values`.  Applied by
+   // `localarenaSetDefaultOptions()` during game setup.
+   private array $localarena_table_options_ = [];
+   private array $localarena_allow_unpublished_option_values_ = [];
+
    // The in-memory "live" id of the framework's game-state machine.
    //
    // This is the LocalArena equivalent of BGA's in-memory current
@@ -498,6 +506,15 @@
      $this->gamestate = new GameState($this, $machinestates);
    }
 
+   // Records the game-option values this table is being created with.
+   // Must be called before `initTable()`, which runs game setup; see
+   // `TableManager::createTable()`.
+   public function localarenaSetTableOptions(array $options, array $allow_unpublished_option_values): void
+   {
+     $this->localarena_table_options_ = $options;
+     $this->localarena_allow_unpublished_option_values_ = $allow_unpublished_option_values;
+   }
+
    function localarenaSetDefaultOptions()
    {
      foreach ($this->game_options as $option_id => $option_desc) {
@@ -509,6 +526,53 @@
          $option_id,
          $option_desc['default'] ?? array_key_first($option_desc['values'])
        );
+     }
+
+     $this->localarenaApplyTableOptions();
+   }
+
+   // Applies the table's chosen game-option values (see
+   // `TableParams::$game_options`) over the defaults just written by
+   // `localarenaSetDefaultOptions()`.  Runs during game setup, before
+   // `setupNewGame()`, so that setup code reads the same values it
+   // would on a real BGA table created with those options.
+   private function localarenaApplyTableOptions(): void
+   {
+     foreach ($this->localarena_table_options_ as $option_id => $value) {
+       if (!array_key_exists($option_id, $this->game_options)) {
+         throw new \BgaVisibleSystemException(
+           'This table was created with a value for game option "' .
+             $option_id .
+             '", which this game does not define.  (Defined options: ' .
+             implode(', ', array_keys($this->game_options)) .
+             '.)'
+         );
+       }
+
+       // A value the game does not publish is reachable only if the
+       // table said so explicitly, one option id at a time: a test
+       // reaching unreleased content is deliberate, whereas the same
+       // value arriving by typo or by a stale copy of the option
+       // definitions is a bug that would otherwise configure a table
+       // no player could ever create.
+       $published_values = $this->game_options[$option_id]['values'] ?? [];
+       if (
+         !array_key_exists($value, $published_values) &&
+         !in_array((string) $option_id, array_map('strval', $this->localarena_allow_unpublished_option_values_), true)
+       ) {
+         throw new \BgaVisibleSystemException(
+           'This table was created with value "' .
+             $value .
+             '" for game option "' .
+             $option_id .
+             '", which that option does not list.  (Listed values: ' .
+             implode(', ', array_keys($published_values)) .
+             '.)  If this value is deliberately unpublished -- e.g. content that is implemented but not yet' .
+             ' offered to players -- name the option id in `TableParams::$allow_unpublished_option_values`.'
+         );
+       }
+
+       $this->localarenaSetGameStateInitialValue($option_id, $value);
      }
    }
 

--- a/src/module/tablemanager/TableParams.php
+++ b/src/module/tablemanager/TableParams.php
@@ -28,6 +28,29 @@ class TableParams
     // defaultTableParams() override -- see UndoTest for an example.
     public bool $enable_undo_savepoints = false;
 
+    // Game-option values for this table, as a map of option id =>
+    // value.  These are applied on top of the defaults from the game's
+    // "gameoptions.json" during game setup, before `setupNewGame()`
+    // runs -- the same point at which a real BGA table has the options
+    // its creator chose -- so setup code sees them.
+    //
+    // Naming an option id that the game does not define is an error.
+    public array $game_options = [];
+
+    // Option ids whose `$game_options` value is allowed not to appear
+    // among that option's published `values`.
+    //
+    // A game may deliberately define an option value that players
+    // cannot select: content that is implemented but not yet released
+    // is typically commented out of "gameoptions.inc.php" so the BGA
+    // lobby never offers it, even though the engine honors the value
+    // if it is set.  Tests need to reach exactly those values, so
+    // supplying one is allowed -- but only deliberately.  Listing the
+    // option id here is that declaration; without it, an unpublished
+    // value throws rather than quietly configuring a table that no
+    // player could create.
+    public array $allow_unpublished_option_values = [];
+
     // The "legacy scope" that the table's legacy data (the
     // `$this->bga->legacy` API) lives under.  Legacy data is shared
     // exactly by the tables of a game that share a scope.

--- a/src/module/tablemanager/tablemanager.php
+++ b/src/module/tablemanager/tablemanager.php
@@ -129,6 +129,12 @@ class TableManager
     }
 
     $game = $this->getTable($table_id);
+
+    // Must precede `initTable()`: that is what runs the game's setup
+    // state, which applies the option defaults and then calls
+    // `setupNewGame()`.
+    $game->localarenaSetTableOptions($params->game_options, $params->allow_unpublished_option_values);
+
     $game->initTable($params->load_schema_file);
 
     if ($params->schema_changes !== '') {

--- a/tests/GameOptionsTest.php
+++ b/tests/GameOptionsTest.php
@@ -1,0 +1,212 @@
+<?php declare(strict_types=1);
+
+namespace LocalArena\Test;
+
+require_once __DIR__ . '/../module/test/IntegrationTestCase.php';
+
+// We extend the bundled "localarenanoop" harness game, so load its class.  When a test supplies a `table_class`,
+// TableManager::getTable() instantiates that class directly and does NOT require the game's .game.php file, so we
+// must require it ourselves before subclassing.
+require_once LOCALARENA_GAME_PATH . 'localarenanoop/localarenanoop.game.php';
+
+/**
+ * Tests for choosing a table's game options at table creation (`TableParams::$game_options`).
+ *
+ * On BGA, a table's options are fixed by its creator before any game code runs, so setup code can read them.  These
+ * tests pin that ordering -- an option value supplied at table creation is visible to `setupNewGame()`, not merely
+ * settable afterwards -- because a game whose setup branches on an option (e.g. which cards to create) cannot be
+ * tested at all if the harness only offers to change options once setup is over.
+ *
+ * They also pin the guard rail on the feature: a value the game does not publish is reachable only when the table
+ * names that option id in `$allow_unpublished_option_values`.  Tests legitimately need unpublished values (that is
+ * how a game hides finished-but-unreleased content from the lobby), but silently accepting any value would let a
+ * typo, or a stale copy of a game's option definitions, configure a table no player could ever create.
+ *
+ * The no-op game's options are defined in src/game/localarenanoop/gameoptions.inc.php.
+ */
+class GameOptionsTest extends IntegrationTestCase
+{
+    const LOCALARENA_GAME_NAME = 'localarenanoop';
+
+    // The no-op game's test option: values 1 and 2 are published, 3 is commented out, and 1 is the default.
+    // (Public because OptionReadingTestGame, below, reads the same option during setup.)
+    public const OPTION_ID = 100;
+    private const VALUE_DEFAULT = 1;
+    private const VALUE_PUBLISHED = 2;
+    private const VALUE_UNPUBLISHED = 3;
+
+    // An option id the no-op game does not define at all.
+    private const UNDEFINED_OPTION_ID = 999;
+
+    // Whether this test got as far as a usable table; see tearDown().
+    private bool $table_created_ = false;
+
+    protected function tearDown(): void
+    {
+        if ($this->table_created_) {
+            parent::tearDown();
+            return;
+        }
+
+        // Table creation threw partway through, so there is no table object to close the process-wide database
+        // connection through -- and the inherited tearDown() would reach for one, silently creating a whole extra
+        // table just to close it.  Close the connection directly instead, so the next test's table connects to its
+        // own database rather than inheriting the abandoned one.
+        $conn = \APP_DbObject::conn();
+        if ($conn !== null) {
+            $conn->close();
+            \APP_DbObject::$static_conn_ = null;
+        }
+    }
+
+    private function initTableWithOptions(
+        array $game_options,
+        array $allow_unpublished_option_values = []
+    ): void {
+        $this->initTable($this->tableParams($game_options, $allow_unpublished_option_values));
+        $this->table_created_ = true;
+    }
+
+    private function tableParams(
+        array $game_options,
+        array $allow_unpublished_option_values = []
+    ): \LocalArena\TableParams {
+        $params = new \LocalArena\TableParams();
+        $params->game = self::LOCALARENA_GAME_NAME;
+        $params->playerCount = 2;
+        // Reuse all of localarenanoop's files, but instantiate our setup-observing subclass instead of the plain
+        // game class.
+        $params->table_class = OptionReadingTestGame::class;
+        $params->game_options = $game_options;
+        $params->allow_unpublished_option_values = $allow_unpublished_option_values;
+        return $params;
+    }
+
+    // Reads an option's value straight out of the globals table, where option values live under their option id.
+    // (Reading it through `getGameStateValue()` instead would require the game to have registered a label for the
+    // option, which the no-op game does not do.)
+    private function optionValue(int $option_id): int
+    {
+        return (int) $this->table()->getUniqueValueFromDB(
+            'SELECT global_value FROM global WHERE global_id = ' . $option_id
+        );
+    }
+
+    /**
+     * A table created without any options gets the defaults from the game's option definitions -- the behavior every
+     * existing test depends on, unchanged by the ability to override.
+     */
+    public function testDefaultsApplyWhenNoOptionsAreGiven(): void
+    {
+        $this->initTableWithOptions([]);
+
+        $this->assertSame(
+            self::VALUE_DEFAULT,
+            $this->optionValue(self::OPTION_ID),
+            'A table created with no options should take each option\'s declared default.'
+        );
+    }
+
+    /**
+     * A published value needs no opt-in: this is the ordinary case, a table created the way a player would create it.
+     */
+    public function testPublishedValueIsApplied(): void
+    {
+        $this->initTableWithOptions([self::OPTION_ID => self::VALUE_PUBLISHED]);
+
+        $this->assertSame(
+            self::VALUE_PUBLISHED,
+            $this->optionValue(self::OPTION_ID),
+            'A published option value supplied at table creation should replace the default.'
+        );
+    }
+
+    /**
+     * The point of applying options at table creation: they must already be in place when the game's own setup runs,
+     * since that is when a game decides what to create.  Verified by reading the value during `setupNewGame()`.
+     */
+    public function testOptionIsVisibleDuringGameSetup(): void
+    {
+        $this->initTableWithOptions([self::OPTION_ID => self::VALUE_PUBLISHED]);
+
+        $this->assertSame(
+            self::VALUE_PUBLISHED,
+            $this->table()->setup_option_read,
+            'The chosen option value must be readable by setupNewGame(), not just after setup has finished.'
+        );
+    }
+
+    /**
+     * An unpublished value is what a test reaching unreleased content actually needs, and it works -- but only with
+     * the explicit declaration.
+     */
+    public function testUnpublishedValueIsAppliedWhenDeclared(): void
+    {
+        $this->initTableWithOptions([self::OPTION_ID => self::VALUE_UNPUBLISHED], [self::OPTION_ID]);
+
+        $this->assertSame(
+            self::VALUE_UNPUBLISHED,
+            $this->optionValue(self::OPTION_ID),
+            'An unpublished value should be applied when its option id is declared in' .
+                ' $allow_unpublished_option_values.'
+        );
+    }
+
+    /**
+     * Without the declaration, the same value throws.  This is the guard rail: it fires on the exact input the
+     * declaration exists to authorize, so a table cannot reach unpublished content by accident.
+     */
+    public function testUnpublishedValueThrowsWhenNotDeclared(): void
+    {
+        $this->expectException(\BgaVisibleSystemException::class);
+        $this->expectExceptionMessage('which that option does not list');
+
+        $this->initTable($this->tableParams([self::OPTION_ID => self::VALUE_UNPUBLISHED]));
+    }
+
+    /**
+     * The declaration is per option id, not a blanket "anything goes" switch: declaring one option must not quietly
+     * authorize unpublished values for another.
+     */
+    public function testDeclarationDoesNotCoverOtherOptions(): void
+    {
+        $this->expectException(\BgaVisibleSystemException::class);
+        $this->expectExceptionMessage('which that option does not list');
+
+        $this->initTable(
+            $this->tableParams([self::OPTION_ID => self::VALUE_UNPUBLISHED], [self::UNDEFINED_OPTION_ID])
+        );
+    }
+
+    /**
+     * An option id the game does not define is always an error -- there is no opt-in for it, because there is no
+     * legitimate reason to set an option that does not exist.  Declaring the id must not rescue it either.
+     */
+    public function testUndefinedOptionIdThrowsEvenWhenDeclared(): void
+    {
+        $this->expectException(\BgaVisibleSystemException::class);
+        $this->expectExceptionMessage('which this game does not define');
+
+        $this->initTable(
+            $this->tableParams([self::UNDEFINED_OPTION_ID => 1], [self::UNDEFINED_OPTION_ID])
+        );
+    }
+}
+
+// The no-op game, plus a record of what the test option read as while `setupNewGame()` was running.  Options are
+// stored under their option id, and the no-op game registers no state labels, so setup reads the global directly --
+// the same value `getGameStateValue()` would return for a game that had labeled the option.
+class OptionReadingTestGame extends \localarenanoop
+{
+    /** @var ?int The test option's value as seen during setup, or null if setup has not run. */
+    public $setup_option_read = null;
+
+    protected function setupNewGame($players, $options = [])
+    {
+        $this->setup_option_read = (int) $this->getUniqueValueFromDB(
+            'SELECT global_value FROM global WHERE global_id = ' . GameOptionsTest::OPTION_ID
+        );
+
+        parent::setupNewGame($players, $options);
+    }
+}


### PR DESCRIPTION
## Summary

A LocalArena table has always taken every game option's default. The only way to change one was to write the global after the fact — by which time the table was fully set up.

On BGA, a table's options are fixed by its creator *before* any game code runs, so `setupNewGame()` can read them. That means a game whose setup branches on an option (deciding which cards to create, say) could not be tested here at all: its tests had to reach in afterwards and mutate the result, which diverges from the production path and cannot undo setup decisions that were already made.

This adds `TableParams::$game_options` — an option id => value map, applied during game setup on top of the defaults and before `setupNewGame()` runs.

```php
$params->game_options = [GAMEOPTION_AGENTS => GAMEOPTION_ALL];
$params->allow_unpublished_option_values = [GAMEOPTION_AGENTS];
```

## The guard rail

A value the game's option definitions do not list is accepted only when the table names that option id in `TableParams::$allow_unpublished_option_values`.

Tests legitimately need such values: commenting a value out of `gameoptions.inc.php` is how a game keeps finished-but-unreleased content out of the BGA lobby while the engine still honors it. But silently accepting any value would let a typo — or a stale copy of a game's option definitions — configure a table that no player could ever create. Naming the option id is the declaration that the omission is understood.

The declaration is per option id, not a blanket switch. An option id the game does not define at all is always an error, since no declaration can make it meaningful.

## Where it hooks in

`TableManager::createTable()` -> `Table::initTable()` -> `enterState()` -> `stGameSetup()`, which calls `localarenaSetDefaultOptions()` and then `setupNewGame()`. That whole cascade runs inside `initTable()`, so `createTable()` now hands the options to the table beforehand, and `localarenaSetDefaultOptions()` applies them over the defaults.

## Changes

- `TableParams`: `$game_options` and `$allow_unpublished_option_values`.
- `TableManager::createTable()`: passes both to the table before `initTable()`.
- `Table`: stores them; `localarenaApplyTableOptions()` validates and applies them after the defaults.
- `localarenanoop`: gains an option to test against, with one deliberately commented-out value standing in for unreleased content. (No constants in that file — it is `include`d afresh per table construction, and a test may build several.)

## Tests

`tests/GameOptionsTest.php`, 7 cases:

- defaults still apply when no options are given (the behavior every existing test depends on)
- a published value is applied
- **the value is visible during `setupNewGame()`** — the case the feature exists for, via a setup-observing subclass following `LegacyTest`'s `table_class` pattern
- an unpublished value is applied when declared
- the same value throws when not declared
- declaring a different option id does not cover it
- an undefined option id throws even when declared

The test overrides `tearDown()`: the inherited one calls `table()`, which would silently create an extra table after the deliberately-throwing cases, so it closes the shared connection directly instead.

## Notes

- Not run locally — no Docker daemon available in this environment, so CI is the first execution of these tests.
- Prettier was deliberately not run: all three `src/module` files touched here were already prettier-dirty on `main`, so reformatting would bury the change.
- Motivation, for context: `bga-theloop` needs this to test expansion agents whose option values are commented out pending release (wardcanyon/bga-theloop#159).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzKexmzsrsSzmN4Njsgj9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzKexmzsrsSzmN4Njsgj9j)_