### PR TITLE
Add counter components (PlayerCounter, TableCounter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,57 @@ from one table into the next) should set
 they share the test's pool.  See `tests/LegacyTest.php` for full
 examples.
 
+#### Counters in tests
+
+The [counter components](https://en.doc.boardgamearena.com/PlayerCounter_and_TableCounter)
+are supported: `$this->counterFactory->createPlayerCounter()` and
+`createTableCounter()`, the `PlayerCounter` and `TableCounter` objects
+they return (`initDb()`, `get()`, `set()`, `inc()`, `getAll()`,
+`setAll()`, `fillResult()`, the visibility and player-key settings),
+and the two counters every game has by default, `$this->playerScore`
+and `$this->playerScoreAux`.
+
+A game's own counters keep their values in the `bga_player_counters`
+and `bga_table_counters` tables of the per-table database, which
+`initDb()` creates; the two default counters are stored in the
+`player` table's `player_score` and `player_score_aux` columns, so
+they need no `initDb()` call.  Every `set()`/`inc()`/`setAll()` sends
+the front end a `setPlayerCounter`, `setTableCounter`, or
+`setPlayerCounterAll` notification, which is what lets an
+`ebg.counter` created with a `playerCounter`/`tableCounter` option
+keep itself up to date without the game touching it.
+
+Counters belong to the game, so tests reach them by name:
+
+```php
+$this->counter('credits');                       // the counter object
+$this->tableCounter('round')->get();
+$this->playerByIndex(0)->counterValue('credits');
+
+$this->assertTableCounter(3, 'round');
+$this->assertPlayerCounter(5, 'credits', $this->playerByIndex(0));
+$this->assertPlayerCounters([$player0_id => 5, $player1_id => 8], 'credits');
+```
+
+A test that needs a counter the game does not define can create one
+itself -- `$this->table()->counterFactory->createPlayerCounter(...)`,
+then `initDb()` -- at any point after the table exists.
+
+`IntegrationTestCase::notifs()` returns the notifications the table has
+sent (optionally filtered by type and recipient), which is how a test
+asserts on what a counter announced:
+
+```php
+$notifs = $this->notifs('setPlayerCounter');
+$this->assertSame(2, $notifs[0]['args']['inc']);
+```
+
+LocalArena is stricter than BGA in three places here, deliberately:
+reading a counter whose `initDb()` was never called is an error rather
+than a silent zero; two counters may not share a name; and player
+counters validate the player id (or no) they are given unless they are
+created with `strict: false`.  See `tests/CountersTest.php`.
+
 ### Generating code-coverage reports
 
 The `testenv` image ships with the [PCOV](https://github.com/krakjoe/pcov)
@@ -357,6 +408,12 @@ $ docker volume rm localarena_db-data
   per-test scopes accumulate rows, much as tests accumulate `table_N`
   databases), and writes to it are not covered by the per-action
   transaction on the table database.
+
+- A player counter whose visibility is not "public" (see
+  "Counters in tests" above) sends its value only to the players who
+  may see it, rather than sending them a redacted notification; so the
+  players who may not see the value do not get the game-log message
+  that accompanied the update either.
 
 ## Tips
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,7 +22,10 @@
 
 ### For testing
 
-- Add test fixtures for notifs.
+- Finish the test fixtures for notifs.  `IntegrationTestCase::notifs()`
+  reads them back out of the gamelog after the fact; we should also be
+  able to observe them as they are sent (and to assert that a player
+  did *not* receive one).
 
 - A missing validation check in "burglebrostwo" made the game's state
   machine run in a tight loop.  Should we have a limit on the number

--- a/src/ebg/core/gamegui.ts
+++ b/src/ebg/core/gamegui.ts
@@ -79,7 +79,16 @@ export class EbgCoreGamegui {
 
     for (const player_id in this.bg_game_players) {
       let scoreCtrl = new ebg.counter();
-      scoreCtrl.create("player_score_" + player_id);
+      // The score controls follow the `playerScore` counter that
+      // every game has by default, so a game that updates
+      // `$this->playerScore` never has to touch them; their starting
+      // value is the "score" field that games are expected to publish
+      // from `getAllDatas()`.
+      scoreCtrl.create("player_score_" + player_id, {
+        value: this.playerScoreFromGamedatas(player_id),
+        playerCounter: "playerScore",
+        playerId: player_id,
+      });
       this.scoreCtrl[player_id] = scoreCtrl;
     }
 
@@ -117,6 +126,16 @@ export class EbgCoreGamegui {
 
     // Transition into initial state.
     this.notif_gameStateChange({ args: gamedatas.gameState });
+  }
+
+  // The starting value for a player's score control: the "score"
+  // field of their entry in the gamedatas, if the game published one.
+  private playerScoreFromGamedatas(player_id): number {
+    const player = this.gamedatas?.players?.[player_id];
+    if (player === undefined || player === null || player.score === undefined || player.score === null) {
+      return 0;
+    }
+    return parseInt("" + player.score);
   }
 
   onUpdateActionButtons(stateName, args) {}

--- a/src/ebg/counter.ts
+++ b/src/ebg/counter.ts
@@ -12,8 +12,73 @@ export default class EbgCounter {
 
   speed: number = 100;
 
-  create(containerId: string): void {
+  // The name of the server-side counter this counter follows, if it
+  // was created with a `playerCounter` or `tableCounter` option; null
+  // otherwise.  See `module/table/LocalArenaCounters.php`.
+  counterName: string = null;
+
+  // True if `counterName` names a PlayerCounter (rather than a
+  // TableCounter).
+  counterIsPlayerCounter: boolean = false;
+
+  // For a player counter, the player whose value this counter shows:
+  // a player id, or a player no if the server-side counter is keyed
+  // that way (see `PlayerCounter::setUseNo()`).  Null means "any
+  // player", which is only useful for a counter that a single player
+  // owns.
+  counterPlayerId: number = null;
+
+  // Associates the counter with the given (already existing) DOM
+  // element.
+  //
+  // With `options.playerCounter` or `options.tableCounter` -- the
+  // name of a server-side counter -- the counter keeps itself up to
+  // date from that counter's notifications, so a game never has to
+  // update it by hand:
+  //
+  //     counter.create(`energy-player-counter-${player.id}`,
+  //                    { value: player.energy, playerCounter: 'energy', playerId: player.id });
+  //
+  //     counter.create(`remaining-tokens-counter`,
+  //                    { value: gamedatas.remainingTokens, tableCounter: 'remainingTokens' });
+  //
+  // `options.value` is the starting value; a null starting value (as
+  // published for a counter whose value this player may not see)
+  // displays "-" instead.
+  create(containerId: string, options?: CounterCreateOptions): void {
     this.el = $(containerId);
+
+    if (options === undefined || options === null) {
+      return;
+    }
+
+    if (options.playerCounter !== undefined && options.tableCounter !== undefined) {
+      console.error(
+        "A counter may follow a player counter or a table counter, but not both: " + containerId,
+      );
+    }
+
+    if (options.playerCounter !== undefined) {
+      this.counterName = options.playerCounter;
+      this.counterIsPlayerCounter = true;
+      this.counterPlayerId =
+        options.playerId === undefined || options.playerId === null
+          ? null
+          : parseInt("" + options.playerId);
+      dojo.subscribe("setPlayerCounter", this, "onSetPlayerCounter");
+      dojo.subscribe("setPlayerCounterAll", this, "onSetPlayerCounterAll");
+    } else if (options.tableCounter !== undefined) {
+      this.counterName = options.tableCounter;
+      dojo.subscribe("setTableCounter", this, "onSetTableCounter");
+    }
+
+    if (options.value !== undefined) {
+      if (options.value === null) {
+        this.disable();
+      } else {
+        this.setValue(options.value);
+      }
+    }
   }
 
   getValue(): number {
@@ -37,6 +102,45 @@ export default class EbgCounter {
 
   disable(): void {
     this.el.innerHTML = "-";
+  }
+
+  // ---- Following a server-side counter ----
+
+  onSetPlayerCounter(notif): void {
+    const args = notif.args;
+    if (!this.followsPlayerCounter(args.name, args.playerId)) {
+      return;
+    }
+    this.toValue(parseInt("" + args.value));
+  }
+
+  onSetPlayerCounterAll(notif): void {
+    const args = notif.args;
+    // Every player's value changed, so this one's did too.
+    if (!this.followsPlayerCounter(args.name, null)) {
+      return;
+    }
+    this.toValue(parseInt("" + args.value));
+  }
+
+  onSetTableCounter(notif): void {
+    const args = notif.args;
+    if (this.counterIsPlayerCounter || args.name !== this.counterName) {
+      return;
+    }
+    this.toValue(parseInt("" + args.value));
+  }
+
+  // Whether an update of `name` for `playerId` (null: for every
+  // player) is an update of what this counter displays.
+  private followsPlayerCounter(name: string, playerId): boolean {
+    if (!this.counterIsPlayerCounter || name !== this.counterName) {
+      return false;
+    }
+    if (playerId === undefined || playerId === null || this.counterPlayerId === null) {
+      return true;
+    }
+    return parseInt("" + playerId) === this.counterPlayerId;
   }
 }
 

--- a/src/ebg/types/framework.d.ts
+++ b/src/ebg/types/framework.d.ts
@@ -29,13 +29,34 @@ type Coords = {
   h: number;
 };
 
+// The options that `Counter.create()` accepts.
+interface CounterCreateOptions {
+  // The counter's starting value; null displays "-" (which is how a
+  // value that this player may not see is published).
+  value?: number | null;
+
+  // The name of the server-side PlayerCounter to follow, so that the
+  // counter updates itself from that counter's notifications.
+  playerCounter?: string;
+
+  // The name of the server-side TableCounter to follow.
+  tableCounter?: string;
+
+  // With `playerCounter`, the player whose value is displayed: their
+  // player id, or their player no if the server-side counter is keyed
+  // that way.
+  playerId?: PlayerId | PlayerIdString;
+}
+
 interface Counter {
   // How fast animations move.
   speed: number;
 
   // Associate the counter with the given DOM element, which must
-  // already exist.
-  create(elId: string): void;
+  // already exist.  With `options.playerCounter`/`options.tableCounter`,
+  // the counter follows a server-side counter of that name and updates
+  // itself whenever it changes.
+  create(elId: string, options?: CounterCreateOptions): void;
 
   // Return the counter's current value.
   getValue(): number;

--- a/src/game/localarenanoop/localarenanoop.game.php
+++ b/src/game/localarenanoop/localarenanoop.game.php
@@ -2,13 +2,27 @@
 
 require_once APP_GAMEMODULE_PATH . "module/table/table.game.php";
 
+use Bga\GameFramework\Components\Counters\PlayerCounter;
+use Bga\GameFramework\Components\Counters\TableCounter;
+
 class localarenanoop extends Table
 {
+    // Counters, so that LocalArena's own tests have a game that goes
+    // through the whole documented lifecycle: created here, given
+    // storage in `setupNewGame()`, and published in `getAllDatas()`.
+    // (Tests that want a counter with some other configuration create
+    // one themselves through `$table->counterFactory`.)
+    public PlayerCounter $playerCredits;
+    public TableCounter $roundCounter;
+
     function __construct()
     {
         parent::__construct();
         self::initGameStateLabels([
         ]);
+
+        $this->playerCredits = $this->counterFactory->createPlayerCounter("credits");
+        $this->roundCounter = $this->counterFactory->createTableCounter("round");
     }
 
     protected function getGameName()
@@ -57,6 +71,9 @@ class localarenanoop extends Table
             $gameinfos["player_colors"]
         );
         self::reloadPlayersBasicInfos();
+
+        $this->playerCredits->initDb(array_keys($players));
+        $this->roundCounter->initDb(1);
     }
 
     /*
@@ -70,7 +87,22 @@ class localarenanoop extends Table
      */
     protected function getAllDatas()
     {
-        return [];
+        $result = [];
+
+        // The default `playerScore` counter is displayed from the
+        // "score" field, so games are expected to publish it here.
+        $result["players"] = self::getCollectionFromDB(
+            "SELECT `player_id` `id`, `player_score` AS `score` FROM `player`"
+        );
+
+        $this->playerCredits->fillResult(
+            $result,
+            /*fieldName=*/ null,
+            /*currentPlayerId=*/ intval(self::getCurrentPlayerId())
+        );
+        $this->roundCounter->fillResult($result);
+
+        return $result;
     }
 
     /*

--- a/src/module/table/LocalArenaCounters.php
+++ b/src/module/table/LocalArenaCounters.php
@@ -1,0 +1,993 @@
+<?php
+
+// Counters: the framework components that store, bound, and publish
+// the plain integers a game keeps track of -- a player's money, the
+// current round, and so on.
+//
+// See https://en.doc.boardgamearena.com/PlayerCounter_and_TableCounter
+//
+// A game creates its counters in its Game class's constructor, using
+// the factory that the framework provides as `$this->counterFactory`:
+//
+//     $this->roundCounter = $this->counterFactory->createTableCounter('round');
+//     $this->playerCredits = $this->counterFactory->createPlayerCounter('credits');
+//
+// and creates their storage during `setupNewGame()`:
+//
+//     $this->roundCounter->initDb();
+//     $this->playerCredits->initDb(array_keys($players));
+//
+// A `TableCounter` holds one value for the whole table; a
+// `PlayerCounter` holds one value per player.  Values live in the
+// per-table database, in `bga_table_counters` and
+// `bga_player_counters` (created by `initDb()`), except for the two
+// counters that every game has by default -- `$this->playerScore` and
+// `$this->playerScoreAux` -- which are stored in the `player_score`
+// and `player_score_aux` columns of the `player` table and therefore
+// need no `initDb()` call.
+//
+// Every `set()`/`inc()`/`setAll()` also sends the front end a
+// notification (`setPlayerCounter`, `setTableCounter`, or
+// `setPlayerCounterAll`), which is what lets an `ebg.counter` created
+// with a `playerCounter`/`tableCounter` option update itself; see
+// `src/ebg/counter.ts`.
+//
+// LocalArena divergences (all deliberate; a game that trips one of
+// these is doing something a BGA table would let it get away with,
+// but that a test is better off being told about):
+//
+//   - Reading a counter whose `initDb()` was never called is an
+//     error, rather than a silent zero.
+//
+//   - Creating two counters with the same name is an error: their
+//     notifications -- and, for two player counters or two table
+//     counters, their rows -- would be indistinguishable.
+//
+//   - A counter whose visibility is not `VISIBLE` does not send its
+//     value to the players who may not see it (rather than sending a
+//     redacted notification), so those players' game logs do not carry
+//     the message that accompanied the update.
+
+namespace Bga\GameFramework\Components\Counters;
+
+require_once APP_GAMEMODULE_PATH . 'module/table/feException.php';
+require_once APP_GAMEMODULE_PATH . 'module/table/BgaVisibleSystemException.php';
+require_once APP_GAMEMODULE_PATH . 'module/table/NotificationMessage.php';
+
+use Bga\GameFramework\NotificationMessage;
+
+// Who may see a player counter's values.
+//
+// The BGA documentation names these "public", "self", and "private";
+// the enum cases are named after the `isVisible()`/`isSelf()`/
+// `isHidden()` predicates that report them.
+enum CounterVisibility
+{
+  // Everyone can see every player's value.  (BGA: "public".)
+  case VISIBLE;
+
+  // Each player can see only their own value; other players' counters
+  // display "-".  (BGA: "self".)
+  case SELF;
+
+  // Nobody can see the values; every counter displays "-".  (BGA:
+  // "private".)  The values are still kept server-side.
+  case HIDDEN;
+}
+
+// Thrown when a `set()`/`inc()` would take a counter outside the
+// [min, max] range it was created with.
+class OutOfRangeCounterException extends \BgaVisibleSystemException
+{
+}
+
+// Thrown when a player counter is asked about a player it does not
+// have a value for -- one that was not passed to `initDb()` -- or,
+// for a "strict" counter, one that is not at the table at all.
+class UnknownPlayerException extends \BgaVisibleSystemException
+{
+}
+
+// The behavior shared by `TableCounter` and `PlayerCounter`: the
+// counter's name, its bounds, and the arguments its notifications
+// carry.
+abstract class Counter
+{
+  // Counter names appear in a `varchar(64)` key column and in
+  // notification arguments; this is what we accept.
+  const NAME_PATTERN = '/^[A-Za-z0-9_\-]{1,64}$/';
+
+  protected \Table $table_;
+  protected string $name_;
+  protected ?int $min_;
+  protected ?int $max_;
+
+  public function __construct(\Table $table, string $name, ?int $min, ?int $max)
+  {
+    if (!preg_match(self::NAME_PATTERN, $name)) {
+      throw new \BgaVisibleSystemException(
+        'Invalid counter name "' .
+          $name .
+          '": names may be up to 64 characters of letters, numbers, underscores, and hyphens.'
+      );
+    }
+    if ($min !== null && $max !== null && $min > $max) {
+      throw new \BgaVisibleSystemException(
+        'Counter "' . $name . '" was created with a minimum (' . $min . ') above its maximum (' . $max . ').'
+      );
+    }
+
+    $this->table_ = $table;
+    $this->name_ = $name;
+    $this->min_ = $min;
+    $this->max_ = $max;
+  }
+
+  // XXX: This is part of the LocalArena API, not the BGA API.  (BGA
+  // does not document an accessor for a counter's own name; test
+  // fixtures want one.)
+  public function getName(): string
+  {
+    return $this->name_;
+  }
+
+  // Returns the lowest value the counter may take, or null if it is
+  // unbounded below.
+  public function getMin(): ?int
+  {
+    return $this->min_;
+  }
+
+  // Returns the highest value the counter may take, or null if it is
+  // unbounded above.
+  public function getMax(): ?int
+  {
+    return $this->max_;
+  }
+
+  protected function checkRange(int $value): void
+  {
+    if (($this->min_ !== null && $value < $this->min_) || ($this->max_ !== null && $value > $this->max_)) {
+      throw new OutOfRangeCounterException(
+        'Counter "' .
+          $this->name_ .
+          '" cannot take the value ' .
+          $value .
+          ': its range is ' .
+          ($this->min_ === null ? '(unbounded)' : strval($this->min_)) .
+          ' to ' .
+          ($this->max_ === null ? '(unbounded)' : strval($this->max_)) .
+          '.'
+      );
+    }
+  }
+
+  // The notification arguments that describe an update, before the
+  // message's own arguments are folded in.
+  protected function updateArgs(int $value, int $old_value): array
+  {
+    return [
+      'name' => $this->name_,
+      'value' => $value,
+      'oldValue' => $old_value,
+      'inc' => $value - $old_value,
+      'absInc' => abs($value - $old_value),
+    ];
+  }
+
+  // Combines a message's arguments with the ones the counter supplies
+  // itself.  The counter's own arguments win: they describe the
+  // update that is being announced.
+  protected function notifArgs(?NotificationMessage $message, array $counter_args): array
+  {
+    return array_merge($message === null ? [] : $message->args, $counter_args);
+  }
+
+  // True if `$table_name` exists in the table's database.
+  protected function dbTableExists(string $table_name): bool
+  {
+    return count($this->table_->getObjectListFromDB("SHOW TABLES LIKE '" . $table_name . "'")) > 0;
+  }
+
+  protected function escapedName(): string
+  {
+    return $this->table_->escapeStringForDB($this->name_);
+  }
+}
+
+// A counter with a single value for the whole table (the current
+// round, the number of tokens left in the bag, ...).
+class TableCounter extends Counter
+{
+  const DB_TABLE = 'bga_table_counters';
+
+  // Creates the counters table if it does not exist yet, and gives
+  // this counter its starting value.  Must be called from
+  // `setupNewGame()` (or, when adding a counter to a game that is
+  // already published, from `upgradeTableDb()`).
+  //
+  // Calling this again for a counter that already has a value leaves
+  // that value alone, so that an `upgradeTableDb()` that adds a
+  // counter can be run against tables that already have one.
+  public function initDb(int $initialValue = 0): void
+  {
+    $this->checkRange($initialValue);
+
+    $this->table_->DbQuery(
+      'CREATE TABLE IF NOT EXISTS `' .
+        self::DB_TABLE .
+        '` (' .
+        '`counter_name` varchar(64) NOT NULL,' .
+        '`counter_value` int(11) NOT NULL,' .
+        'PRIMARY KEY (`counter_name`)' .
+        ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+    );
+
+    $this->table_->DbQuery(
+      'INSERT IGNORE INTO `' .
+        self::DB_TABLE .
+        "` (`counter_name`, `counter_value`) VALUES ('" .
+        $this->escapedName() .
+        "'," .
+        $initialValue .
+        ')'
+    );
+  }
+
+  // Returns the counter's current value.
+  public function get(): int
+  {
+    $rows = $this->dbTableExists(self::DB_TABLE)
+      ? $this->table_->getObjectListFromDB(
+        'SELECT `counter_value` FROM `' . self::DB_TABLE . "` WHERE `counter_name` = '" . $this->escapedName() . "'",
+        /*bUniqueValue=*/ true
+      )
+      : [];
+
+    if (count($rows) === 0) {
+      throw new \BgaVisibleSystemException(
+        'Table counter "' .
+          $this->name_ .
+          '" has no value: initDb() must be called for it from setupNewGame() (or, for a game that is already ' .
+          'published, from upgradeTableDb()).'
+      );
+    }
+    return intval($rows[0]);
+  }
+
+  // Sets the counter's value, announces it to the front end, and
+  // returns the new value.
+  public function set(int $value, ?NotificationMessage $message = new NotificationMessage()): int
+  {
+    $old_value = $this->get();
+    $this->checkRange($value);
+    $this->write($value);
+    $this->notify($value, $old_value, $message);
+    return $value;
+  }
+
+  // Adds `$inc` to the counter's value, announces it to the front
+  // end, and returns the new value.  An increment of 0 changes
+  // nothing and sends no notification.
+  public function inc(int $inc, ?NotificationMessage $message = new NotificationMessage()): int
+  {
+    $old_value = $this->get();
+    if ($inc === 0) {
+      return $old_value;
+    }
+    $value = $old_value + $inc;
+    $this->checkRange($value);
+    $this->write($value);
+    $this->notify($value, $old_value, $message);
+    return $value;
+  }
+
+  // Sets the counter's value in `$result` (the array that
+  // `getAllDatas()` returns), under `$fieldName` if given and the
+  // counter's own name otherwise.
+  public function fillResult(array &$result, ?string $fieldName = null): void
+  {
+    $result[$fieldName ?? $this->name_] = $this->get();
+  }
+
+  private function write(int $value): void
+  {
+    $this->table_->DbQuery(
+      'UPDATE `' .
+        self::DB_TABLE .
+        '` SET `counter_value` = ' .
+        $value .
+        " WHERE `counter_name` = '" .
+        $this->escapedName() .
+        "'"
+    );
+  }
+
+  private function notify(int $value, int $old_value, ?NotificationMessage $message): void
+  {
+    if ($message === null) {
+      return;
+    }
+    $this->table_->notifyAllPlayers(
+      'setTableCounter',
+      $message->message,
+      $this->notifArgs($message, $this->updateArgs($value, $old_value))
+    );
+  }
+}
+
+// A counter with one value per player (a player's money, their
+// remaining actions, ...).
+class PlayerCounter extends Counter
+{
+  private CounterVisibility $visibility_;
+  private bool $useNo_;
+  private bool $strict_;
+  private LocalArenaPlayerCounterStore $store_;
+
+  // XXX: This is part of the LocalArena API, not the BGA API; games
+  // create player counters through `$this->counterFactory`.
+  public function __construct(
+    \Table $table,
+    string $name,
+    ?int $min,
+    ?int $max,
+    CounterVisibility $visibility,
+    bool $useNo,
+    bool $strict,
+    LocalArenaPlayerCounterStore $store
+  ) {
+    parent::__construct($table, $name, $min, $max);
+    $this->visibility_ = $visibility;
+    $this->useNo_ = $useNo;
+    $this->strict_ = $strict;
+    $this->store_ = $store;
+  }
+
+  // Creates the counters table if it does not exist yet, and gives
+  // this counter a starting value for each of `$playerIdsOrNos`
+  // (usually `array_keys($players)`, but a game may add e.g. 0 for an
+  // automaton).  Must be called from `setupNewGame()` (or, when
+  // adding a counter to a game that is already published, from
+  // `upgradeTableDb()`).
+  //
+  // Players who already have a value keep it, so that an
+  // `upgradeTableDb()` that adds a counter can be run against tables
+  // that already have one.
+  public function initDb(array $playerIdsOrNos, int $initialValue = 0): void
+  {
+    $this->checkRange($initialValue);
+    $this->store_->initDb(array_map('intval', array_values($playerIdsOrNos)), $initialValue);
+  }
+
+  // Returns the counter's current value for the given player.
+  public function get(int $playerIdOrNo): int
+  {
+    $this->checkStrict($playerIdOrNo);
+    $value = $this->store_->get($playerIdOrNo);
+    if ($value === null) {
+      throw new UnknownPlayerException($this->unknownPlayerMessage($playerIdOrNo));
+    }
+    return $value;
+  }
+
+  // Sets the counter's value for the given player, announces it to
+  // the front end, and returns the new value.
+  public function set(int $playerIdOrNo, int $value, ?NotificationMessage $message = new NotificationMessage()): int
+  {
+    $old_value = $this->get($playerIdOrNo);
+    $this->checkRange($value);
+    $this->store_->set($playerIdOrNo, $value);
+    $this->notify($playerIdOrNo, $value, $old_value, $message);
+    return $value;
+  }
+
+  // Adds `$inc` to the counter's value for the given player,
+  // announces it to the front end, and returns the new value.  An
+  // increment of 0 changes nothing and sends no notification.
+  public function inc(int $playerIdOrNo, int $inc, ?NotificationMessage $message = new NotificationMessage()): int
+  {
+    $old_value = $this->get($playerIdOrNo);
+    if ($inc === 0) {
+      return $old_value;
+    }
+    $value = $old_value + $inc;
+    $this->checkRange($value);
+    $this->store_->set($playerIdOrNo, $value);
+    $this->notify($playerIdOrNo, $value, $old_value, $message);
+    return $value;
+  }
+
+  // Returns every player's value, as an array mapping player id (or
+  // player no, for a "useNo" counter) to value.
+  public function getAll(): array
+  {
+    return $this->store_->getAll();
+  }
+
+  // Sets the counter's value for every player it has a value for,
+  // announces it to the front end, and returns the new value.
+  public function setAll(int $value, ?NotificationMessage $message = new NotificationMessage()): int
+  {
+    $this->checkRange($value);
+    $this->store_->setAll($value);
+    $this->notifyAll($value, $message);
+    return $value;
+  }
+
+  // Sets each player's value on their sub-array of
+  // `$result['players']` (the array that `getAllDatas()` returns),
+  // under `$fieldName` if given and the counter's own name otherwise.
+  //
+  // Values the viewer may not see are filled in as null, which is
+  // what makes the front-end counter display "-":
+  //
+  //   - a "self" counter shows only `$currentPlayerId`'s own value
+  //     (and, with no `$currentPlayerId`, nothing at all);
+  //   - a "private" counter shows nothing.
+  public function fillResult(array &$result, ?string $fieldName = null, ?int $currentPlayerId = null): void
+  {
+    if (!isset($result['players']) || !is_array($result['players'])) {
+      throw new \BgaVisibleSystemException(
+        'PlayerCounter::fillResult() for counter "' .
+          $this->name_ .
+          '" needs $result["players"] to be an array of per-player data.'
+      );
+    }
+
+    $field = $fieldName ?? $this->name_;
+    $values = $this->valuesByPlayerId();
+
+    foreach ($result['players'] as $player_id => &$player_data) {
+      if (!is_array($player_data)) {
+        continue;
+      }
+      $value = $values[intval($player_id)] ?? null;
+      $player_data[$field] = $this->isValueVisibleTo(intval($player_id), $currentPlayerId) ? $value : null;
+    }
+    // `foreach` by reference leaves $player_data aliasing the last
+    // element; break that alias before it can bite a later write.
+    unset($player_data);
+  }
+
+  // ---- Visibility ----
+
+  public function setVisibility(CounterVisibility $visibility): void
+  {
+    $this->visibility_ = $visibility;
+  }
+
+  // XXX: This is part of the LocalArena API, not the BGA API.
+  public function getVisibility(): CounterVisibility
+  {
+    return $this->visibility_;
+  }
+
+  // True if everyone can see every player's value.
+  public function isVisible(): bool
+  {
+    return $this->visibility_ === CounterVisibility::VISIBLE;
+  }
+
+  // True if nobody can see the values.
+  public function isHidden(): bool
+  {
+    return $this->visibility_ === CounterVisibility::HIDDEN;
+  }
+
+  // True if each player can see only their own value.
+  public function isSelf(): bool
+  {
+    return $this->visibility_ === CounterVisibility::SELF;
+  }
+
+  // ---- Player identification ----
+
+  // Chooses whether this counter's methods take player nos (true) or
+  // player ids (false).
+  //
+  // Note that this does not rewrite anything already stored: the keys
+  // written by `initDb()` are whatever was passed to it.
+  public function setUseNo(bool $useNo): void
+  {
+    $this->useNo_ = $useNo;
+    $this->store_->setUseNo($useNo);
+  }
+
+  // XXX: This is part of the LocalArena API, not the BGA API.
+  public function getUseNo(): bool
+  {
+    return $this->useNo_;
+  }
+
+  // Chooses whether the player id (or no) passed to this counter's
+  // methods is validated against the players at the table.
+  public function setStrict(bool $strict): void
+  {
+    $this->strict_ = $strict;
+  }
+
+  // XXX: This is part of the LocalArena API, not the BGA API.
+  public function getStrict(): bool
+  {
+    return $this->strict_;
+  }
+
+  // ---- Internals ----
+
+  // For a strict counter, rejects a player id (or no) that is not at
+  // the table.  Note that a counter may legitimately hold values for
+  // keys that are not players -- 0 for an automaton, say -- which is
+  // exactly what such a counter turns strictness off for.
+  private function checkStrict(int $playerIdOrNo): void
+  {
+    if (!$this->strict_) {
+      return;
+    }
+    if ($this->playerRow($playerIdOrNo) === null) {
+      throw new UnknownPlayerException(
+        'Counter "' .
+          $this->name_ .
+          '" is strict, and there is no player with ' .
+          ($this->useNo_ ? 'player no ' : 'player id ') .
+          $playerIdOrNo .
+          ' at this table.'
+      );
+    }
+  }
+
+  private function unknownPlayerMessage(int $playerIdOrNo): string
+  {
+    return 'Counter "' .
+      $this->name_ .
+      '" has no value for ' .
+      ($this->useNo_ ? 'player no ' : 'player id ') .
+      $playerIdOrNo .
+      ': it was not among the players passed to initDb().';
+  }
+
+  // The `player` row for a player id (or no), or null if there is no
+  // such player at the table.
+  private function playerRow(int $playerIdOrNo)
+  {
+    $row = $this->table_->getObjectFromDB(
+      'SELECT * FROM `player` WHERE `' . ($this->useNo_ ? 'player_no' : 'player_id') . '` = ' . $playerIdOrNo
+    );
+    return $row === null || count($row) === 0 ? null : $row;
+  }
+
+  // This counter's values, re-keyed by player id even when the
+  // counter itself is keyed by player no.  Keys that do not belong to
+  // a player at the table (an automaton's, say) are dropped.
+  private function valuesByPlayerId(): array
+  {
+    $values = $this->getAll();
+    if (!$this->useNo_) {
+      return $values;
+    }
+
+    $player_ids_by_no = $this->table_->getCollectionFromDB(
+      'SELECT `player_no`, `player_id` FROM `player`',
+      /*bSingleValue=*/ true
+    );
+
+    $by_id = [];
+    foreach ($values as $no => $value) {
+      if (isset($player_ids_by_no[$no])) {
+        $by_id[intval($player_ids_by_no[$no])] = $value;
+      }
+    }
+    return $by_id;
+  }
+
+  // Whether `$viewer_id` (null for "no particular player", e.g. a
+  // notification sent to everyone) may see `$player_id`'s value.
+  private function isValueVisibleTo(int $player_id, ?int $viewer_id): bool
+  {
+    return match ($this->visibility_) {
+      CounterVisibility::VISIBLE => true,
+      CounterVisibility::SELF => $viewer_id !== null && $viewer_id === $player_id,
+      CounterVisibility::HIDDEN => false,
+    };
+  }
+
+  // Announces an update of one player's value to the players who may
+  // see it: everyone for a "public" counter, the owning player alone
+  // for a "self" counter, nobody for a "private" one.
+  private function notify(int $playerIdOrNo, int $value, int $old_value, ?NotificationMessage $message): void
+  {
+    if ($message === null || $this->isHidden()) {
+      return;
+    }
+
+    $row = $this->playerRow($playerIdOrNo);
+    $counter_args = $this->updateArgs($value, $old_value);
+    // The front end matches counters on whatever this counter is
+    // keyed by, so this carries the caller's key (see `useNo`).
+    $counter_args['playerId'] = $playerIdOrNo;
+    if ($row !== null) {
+      $counter_args['player_name'] = $row['player_name'];
+    }
+    $args = $this->notifArgs($message, $counter_args);
+
+    if ($this->isSelf()) {
+      if ($row !== null) {
+        $this->table_->notifyPlayer(intval($row['player_id']), 'setPlayerCounter', $message->message, $args);
+      }
+      return;
+    }
+    $this->table_->notifyAllPlayers('setPlayerCounter', $message->message, $args);
+  }
+
+  // Announces a `setAll()`.  Since every player's value is the same,
+  // there is no per-player `oldValue`/`inc` to report.
+  private function notifyAll(int $value, ?NotificationMessage $message): void
+  {
+    if ($message === null || $this->isHidden()) {
+      return;
+    }
+
+    $args = $this->notifArgs($message, ['name' => $this->name_, 'value' => $value]);
+
+    if ($this->isSelf()) {
+      foreach (array_keys($this->table_->rawGetPlayers()) as $player_id) {
+        $this->table_->notifyPlayer(intval($player_id), 'setPlayerCounterAll', $message->message, $args);
+      }
+      return;
+    }
+    $this->table_->notifyAllPlayers('setPlayerCounterAll', $message->message, $args);
+  }
+}
+
+// Where a player counter's values live.
+//
+// XXX: This is part of the LocalArena API, not the BGA API.  Ordinary
+// counters are stored in `bga_player_counters`
+// (`LocalArenaPlayerCounterTableStore`); the two counters that every
+// game has by default are stored in the `player` table
+// (`LocalArenaPlayerColumnStore`), which is why they need no
+// `initDb()`.
+abstract class LocalArenaPlayerCounterStore
+{
+  protected \Table $table_;
+  protected bool $useNo_;
+
+  public function __construct(\Table $table, bool $useNo)
+  {
+    $this->table_ = $table;
+    $this->useNo_ = $useNo;
+  }
+
+  public function setUseNo(bool $useNo): void
+  {
+    $this->useNo_ = $useNo;
+  }
+
+  // Creates whatever storage is needed and gives each of `$keys` the
+  // starting value, leaving any existing value alone.
+  abstract public function initDb(array $keys, int $initial_value): void;
+
+  // The value stored for `$key`, or null if there is none.
+  abstract public function get(int $key): ?int;
+
+  // Every stored value, as key => value.
+  abstract public function getAll(): array;
+
+  abstract public function set(int $key, int $value): void;
+
+  abstract public function setAll(int $value): void;
+}
+
+// The default storage: one row per (counter, player) in
+// `bga_player_counters`.
+class LocalArenaPlayerCounterTableStore extends LocalArenaPlayerCounterStore
+{
+  const DB_TABLE = 'bga_player_counters';
+
+  private string $name_;
+
+  public function __construct(\Table $table, string $name, bool $useNo)
+  {
+    parent::__construct($table, $useNo);
+    $this->name_ = $name;
+  }
+
+  public function initDb(array $keys, int $initial_value): void
+  {
+    $this->table_->DbQuery(
+      'CREATE TABLE IF NOT EXISTS `' .
+        self::DB_TABLE .
+        '` (' .
+        '`counter_name` varchar(64) NOT NULL,' .
+        // The player id, or the player no for a "useNo" counter; a
+        // game may also use a key that is neither (0 for an
+        // automaton, say).
+        '`player_id` int(11) NOT NULL,' .
+        '`counter_value` int(11) NOT NULL,' .
+        'PRIMARY KEY (`counter_name`, `player_id`)' .
+        ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+    );
+
+    if (count($keys) === 0) {
+      return;
+    }
+
+    $values = [];
+    foreach ($keys as $key) {
+      $values[] = "('" . $this->escapedName() . "'," . $key . ',' . $initial_value . ')';
+    }
+    $this->table_->DbQuery(
+      'INSERT IGNORE INTO `' .
+        self::DB_TABLE .
+        '` (`counter_name`, `player_id`, `counter_value`) VALUES ' .
+        implode(',', $values)
+    );
+  }
+
+  public function get(int $key): ?int
+  {
+    if (!$this->tableExists()) {
+      return null;
+    }
+    $rows = $this->table_->getObjectListFromDB(
+      'SELECT `counter_value` FROM `' .
+        self::DB_TABLE .
+        "` WHERE `counter_name` = '" .
+        $this->escapedName() .
+        "' AND `player_id` = " .
+        $key,
+      /*bUniqueValue=*/ true
+    );
+    return count($rows) === 0 ? null : intval($rows[0]);
+  }
+
+  public function getAll(): array
+  {
+    if (!$this->tableExists()) {
+      return [];
+    }
+    $rows = $this->table_->getCollectionFromDB(
+      'SELECT `player_id`, `counter_value` FROM `' .
+        self::DB_TABLE .
+        "` WHERE `counter_name` = '" .
+        $this->escapedName() .
+        "' ORDER BY `player_id` ASC",
+      /*bSingleValue=*/ true
+    );
+
+    $values = [];
+    foreach ($rows as $key => $value) {
+      $values[intval($key)] = intval($value);
+    }
+    return $values;
+  }
+
+  public function set(int $key, int $value): void
+  {
+    $this->table_->DbQuery(
+      'UPDATE `' .
+        self::DB_TABLE .
+        '` SET `counter_value` = ' .
+        $value .
+        " WHERE `counter_name` = '" .
+        $this->escapedName() .
+        "' AND `player_id` = " .
+        $key
+    );
+  }
+
+  public function setAll(int $value): void
+  {
+    if (!$this->tableExists()) {
+      return;
+    }
+    $this->table_->DbQuery(
+      'UPDATE `' .
+        self::DB_TABLE .
+        '` SET `counter_value` = ' .
+        $value .
+        " WHERE `counter_name` = '" .
+        $this->escapedName() .
+        "'"
+    );
+  }
+
+  private function tableExists(): bool
+  {
+    return count($this->table_->getObjectListFromDB("SHOW TABLES LIKE '" . self::DB_TABLE . "'")) > 0;
+  }
+
+  private function escapedName(): string
+  {
+    return $this->table_->escapeStringForDB($this->name_);
+  }
+}
+
+// The storage behind `$this->playerScore` and
+// `$this->playerScoreAux`: a column of the `player` table, so that
+// updating the counter updates the score BGA itself reads, and so
+// that the counter needs no `initDb()` -- every player at the table
+// has a value from the moment they are seated.
+class LocalArenaPlayerColumnStore extends LocalArenaPlayerCounterStore
+{
+  private string $column_;
+
+  public function __construct(\Table $table, string $column, bool $useNo)
+  {
+    parent::__construct($table, $useNo);
+    $this->column_ = $column;
+  }
+
+  public function initDb(array $keys, int $initial_value): void
+  {
+    // The rows already exist (they are the players); all that is left
+    // is the starting value.
+    foreach ($keys as $key) {
+      $this->set($key, $initial_value);
+    }
+  }
+
+  public function get(int $key): ?int
+  {
+    $rows = $this->table_->getObjectListFromDB(
+      'SELECT `' . $this->column_ . '` FROM `player` WHERE `' . $this->keyColumn() . '` = ' . $key,
+      /*bUniqueValue=*/ true
+    );
+    return count($rows) === 0 ? null : intval($rows[0]);
+  }
+
+  public function getAll(): array
+  {
+    $rows = $this->table_->getCollectionFromDB(
+      'SELECT `' . $this->keyColumn() . '`, `' . $this->column_ . '` FROM `player` ORDER BY `player_no` ASC',
+      /*bSingleValue=*/ true
+    );
+
+    $values = [];
+    foreach ($rows as $key => $value) {
+      $values[intval($key)] = intval($value);
+    }
+    return $values;
+  }
+
+  public function set(int $key, int $value): void
+  {
+    $this->table_->DbQuery(
+      'UPDATE `player` SET `' . $this->column_ . '` = ' . $value . ' WHERE `' . $this->keyColumn() . '` = ' . $key
+    );
+  }
+
+  public function setAll(int $value): void
+  {
+    $this->table_->DbQuery('UPDATE `player` SET `' . $this->column_ . '` = ' . $value);
+  }
+
+  private function keyColumn(): string
+  {
+    return $this->useNo_ ? 'player_no' : 'player_id';
+  }
+}
+
+// The factory that games create their counters with, available as
+// `$this->counterFactory`.
+class CounterFactory
+{
+  private \Table $table_;
+
+  // Every counter this factory has created, by name; see
+  // `localarenaGetCounter()`.
+  private array $counters_ = [];
+
+  public function __construct(\Table $table)
+  {
+    $this->table_ = $table;
+  }
+
+  // Creates a counter with one value per player.
+  //
+  // `$min`/`$max` bound the values it may take (null for unbounded);
+  // `$visibility` says who may see them; `$useNo` makes the counter's
+  // methods take player nos rather than player ids; and `$strict`
+  // makes them reject a player who is not at the table.
+  //
+  // `$strict` defaults to null, meaning "let the framework decide".
+  // LocalArena, being a development and testing environment (like BGA
+  // Studio, and unlike production), decides to validate.  A counter
+  // that deliberately holds values for keys that are not players --
+  // an automaton's, say -- should pass `strict: false`.
+  public function createPlayerCounter(
+    string $name,
+    ?int $min = 0,
+    ?int $max = null,
+    CounterVisibility $visibility = CounterVisibility::VISIBLE,
+    bool $useNo = false,
+    ?bool $strict = null
+  ): PlayerCounter {
+    $counter = new PlayerCounter(
+      $this->table_,
+      $name,
+      $min,
+      $max,
+      $visibility,
+      $useNo,
+      $strict ?? true,
+      new LocalArenaPlayerCounterTableStore($this->table_, $name, $useNo)
+    );
+    $this->register($counter);
+    return $counter;
+  }
+
+  // Creates a counter with a single value for the whole table.
+  public function createTableCounter(string $name, ?int $min = 0, ?int $max = null): TableCounter
+  {
+    $counter = new TableCounter($this->table_, $name, $min, $max);
+    $this->register($counter);
+    return $counter;
+  }
+
+  // Creates one of the counters that every game has by default:
+  // player counters stored in a column of the `player` table, so that
+  // they need no `initDb()` and so that setting them keeps the score
+  // BGA reads up to date.
+  //
+  // XXX: This is part of the LocalArena API, not the BGA API; it is
+  // intended only for internal use (by `Table`).
+  public function localarenaCreatePlayerColumnCounter(string $name, string $column): PlayerCounter
+  {
+    $counter = new PlayerCounter(
+      $this->table_,
+      $name,
+      // The default score counters are unbounded, and are not strict
+      // (so that a game may keep a score for e.g. an automaton
+      // without tripping validation).
+      /*min=*/ null,
+      /*max=*/ null,
+      CounterVisibility::VISIBLE,
+      /*useNo=*/ false,
+      /*strict=*/ false,
+      new LocalArenaPlayerColumnStore($this->table_, $column, /*useNo=*/ false)
+    );
+    $this->register($counter);
+    return $counter;
+  }
+
+  // Returns the counter with the given name.
+  //
+  // XXX: This is part of the LocalArena API, not the BGA API; games
+  // hold on to the counters they create (test fixtures cannot).
+  public function localarenaGetCounter(string $name): Counter
+  {
+    if (!array_key_exists($name, $this->counters_)) {
+      throw new \BgaVisibleSystemException(
+        'This game has no counter named "' .
+          $name .
+          '".  (Counters: ' .
+          (count($this->counters_) === 0 ? 'none' : implode(', ', array_keys($this->counters_))) .
+          '.)'
+      );
+    }
+    return $this->counters_[$name];
+  }
+
+  // Returns every counter this game has created, by name.
+  //
+  // XXX: This is part of the LocalArena API, not the BGA API.
+  public function localarenaGetCounters(): array
+  {
+    return $this->counters_;
+  }
+
+  private function register(Counter $counter): void
+  {
+    $name = $counter->getName();
+    if (array_key_exists($name, $this->counters_)) {
+      throw new \BgaVisibleSystemException(
+        'This game has already created a counter named "' .
+          $name .
+          '".  Counter names identify a counter to the front end (and, for player and table counters alike, in the ' .
+          'database), so they must be unique.'
+      );
+    }
+    $this->counters_[$name] = $counter;
+  }
+}

--- a/src/module/table/NotificationMessage.php
+++ b/src/module/table/NotificationMessage.php
@@ -1,0 +1,39 @@
+<?php
+
+// `Bga\GameFramework\NotificationMessage`: the message (and extra
+// arguments) that a framework component sends along with the
+// notification it produces.
+//
+// Components that update the front-end -- currently the counters (see
+// `LocalArenaCounters.php`) -- take one of these wherever BGA's API
+// documents a `?\Bga\GameFramework\NotificationMessage $message`
+// parameter:
+//
+//   - A `NotificationMessage` with a non-empty message: the
+//     notification is sent, and the message appears in the game log.
+//   - A `NotificationMessage` with an empty message (the default):
+//     the notification is sent, but nothing appears in the game log.
+//   - `null`: no notification is sent at all, so the front end is not
+//     updated.
+//
+// The component supplies the arguments that describe what it did (for
+// counters: `name`, `value`, `oldValue`, `inc`, `absInc`, and, for
+// player counters, `playerId` and `player_name`), so `$args` only
+// needs to carry the arguments that are specific to the message.
+
+namespace Bga\GameFramework;
+
+class NotificationMessage
+{
+  public function __construct(
+    // The game-log message.  Should be wrapped in `clienttranslate()`
+    // (as ever, at the point where the literal appears).  An empty
+    // message means "update the front end, but log nothing".
+    public string $message = '',
+
+    // Substitution arguments for `$message`, beyond those that the
+    // sending component supplies itself.
+    public array $args = []
+  ) {
+  }
+}

--- a/src/module/table/empty_database.sql
+++ b/src/module/table/empty_database.sql
@@ -1,3 +1,5 @@
+Drop table if exists `bga_player_counters`;
+Drop table if exists `bga_table_counters`;
 Drop table if exists `gamelog`;
 Drop table if exists `global`;
 Drop table if exists `player`;
@@ -96,7 +98,7 @@ CREATE TABLE `stats` (
 
 
 --
--- Index pour les tables exportées
+-- Index pour les tables exportï¿½es
 --
 
 --
@@ -133,7 +135,7 @@ ALTER TABLE `stats`
   ADD KEY `stats_player_id` (`stats_player_id`);
 
 --
--- AUTO_INCREMENT pour les tables exportées
+-- AUTO_INCREMENT pour les tables exportï¿½es
 --
 
 --

--- a/src/module/table/table.game.php
+++ b/src/module/table/table.game.php
@@ -7,6 +7,8 @@
  require_once APP_GAMEMODULE_PATH . 'module/table/GameState.php';
  require_once APP_GAMEMODULE_PATH . 'module/table/LocalArenaStats.php';
  require_once APP_GAMEMODULE_PATH . 'module/table/LocalArenaLegacy.php';
+ require_once APP_GAMEMODULE_PATH . 'module/table/NotificationMessage.php';
+ require_once APP_GAMEMODULE_PATH . 'module/table/LocalArenaCounters.php';
  require_once APP_GAMEMODULE_PATH . 'module/table/LocalArenaBgaServices.php';
  require_once APP_GAMEMODULE_PATH . 'module/table/APP_GameAction.php';
  require_once APP_GAMEMODULE_PATH . 'module/table/deck.php';
@@ -392,6 +394,25 @@
    public TableStats $tableStats;
    public PlayerStats $playerStats;
 
+   // The counter APIs; see `module/table/LocalArenaCounters.php` and
+   // https://en.doc.boardgamearena.com/PlayerCounter_and_TableCounter
+   //
+   // Games create their own counters with the factory, in their Game
+   // class's constructor:
+   //
+   //     $this->roundCounter = $this->counterFactory->createTableCounter('round');
+   //
+   public \Bga\GameFramework\Components\Counters\CounterFactory $counterFactory;
+
+   // The two player counters that every game has by default.  Unlike
+   // the counters a game creates, these are stored in the `player`
+   // table's `player_score` and `player_score_aux` columns -- so they
+   // need no `initDb()`, and setting them is what keeps the scores
+   // that the framework itself reads up to date.  They are unbounded
+   // and start at 0.
+   public \Bga\GameFramework\Components\Counters\PlayerCounter $playerScore;
+   public \Bga\GameFramework\Components\Counters\PlayerCounter $playerScoreAux;
+
    // The modern object-based services API; carries the legacy-games
    // API as `$this->bga->legacy`.
    public LocalArenaBgaServices $bga;
@@ -470,6 +491,16 @@
      $this->tableStats = new TableStats($this);
      $this->playerStats = new PlayerStats($this);
      $this->bga = new LocalArenaBgaServices($this);
+
+     // The counter factory must exist before the game's own
+     // constructor body runs: that is where games create their
+     // counters.
+     $this->counterFactory = new \Bga\GameFramework\Components\Counters\CounterFactory($this);
+     $this->playerScore = $this->counterFactory->localarenaCreatePlayerColumnCounter('playerScore', 'player_score');
+     $this->playerScoreAux = $this->counterFactory->localarenaCreatePlayerColumnCounter(
+       'playerScoreAux',
+       'player_score_aux'
+     );
 
      $gameoptions_json_path = LOCALARENA_GAME_PATH . $this->getGameName() . '/gameoptions.json';
      $gamepreferences_json_path = LOCALARENA_GAME_PATH . $this->getGameName() . '/gamepreferences.json';
@@ -838,6 +869,39 @@
      // XXX: no-op; but in strict mode, this should throw an exception
    }
 
+   // Combines the game's `getAllDatas()` with the framework's own
+   // "medium" data (see `getMediumDatas()`) to produce the gamedatas
+   // served to a client.
+   //
+   // The per-player sub-arrays are merged rather than replaced: on
+   // BGA, `gamedatas.players[$player_id]` carries the framework's
+   // information about a player (name, color, ...) ALONGSIDE whatever
+   // the game published for them in `$result['players']`.  A plain
+   // `array_merge()` of the two would drop the latter entirely, so
+   // per-player data -- notably the values that
+   // `PlayerCounter::fillResult()` writes, which is where a front-end
+   // counter gets its starting value -- would never reach the client.
+   //
+   // Where both sides define the same field for a player, the game's
+   // value wins: `getAllDatas()` is what the game controls.
+   private function mergeMediumDatas(array $alldatas, array $medium_datas): array
+   {
+     if (
+       isset($alldatas['players']) &&
+       is_array($alldatas['players']) &&
+       isset($medium_datas['players']) &&
+       is_array($medium_datas['players'])
+     ) {
+       foreach ($medium_datas['players'] as $player_id => $player_info) {
+         $game_data = $alldatas['players'][$player_id] ?? null;
+         if (is_array($game_data)) {
+           $medium_datas['players'][$player_id] = array_merge($player_info, $game_data);
+         }
+       }
+     }
+     return array_merge($alldatas, $medium_datas);
+   }
+
    function getFullDatas()
    {
      $ret = $this->getMediumDatas();
@@ -852,7 +916,7 @@
        $ret['alldatas'] = json_decode($data);
      } else {
        // XXX:
-       $ret['alldatas'] = array_merge($this->getAllDatasValidated(), $this->getMediumDatas());
+       $ret['alldatas'] = $this->mergeMediumDatas($this->getAllDatasValidated(), $this->getMediumDatas());
      }
 
      $ret['states'] = $this->gamestate->machinestates;
@@ -1711,7 +1775,11 @@
        ',' .
        $this->getCurrentPlayerId() .
        ',\'' .
-       $data .
+       // As in `notifyAllPlayers()`: the JSON goes into a string
+       // literal, so it has to be escaped (a notification argument
+       // containing a quote or a backslash would otherwise be
+       // mangled, or break the query outright).
+       $this->escapeStringForDb($data) .
        '\')';
      $this->DbQuery($sql);
    }

--- a/src/module/test/IntegrationTestCase.php
+++ b/src/module/test/IntegrationTestCase.php
@@ -16,6 +16,9 @@ define('APP_GAMEMODULE_PATH', '/src/localarena/');
 define('LOCALARENA_GAME_PATH', '/src/game/');
 
 use \LocalArena\TableParams;
+use \Bga\GameFramework\Components\Counters\Counter;
+use \Bga\GameFramework\Components\Counters\PlayerCounter;
+use \Bga\GameFramework\Components\Counters\TableCounter;
 
 // The game-specific view code expects this.
 //
@@ -280,6 +283,148 @@ class IntegrationTestCase extends \PHPUnit\Framework\TestCase
     );
   }
 
+  // ==================== Counters ====================
+  //
+  // Counters are created by the game (in its Game class's
+  // constructor), so a test reaches them by name rather than by
+  // holding a reference: `counter('credits')` finds the same object
+  // the game holds.  The two counters every game has by default are
+  // named "playerScore" and "playerScoreAux".
+  //
+  // A test that needs a counter the game does not define can create
+  // one itself -- `$this->table()->counterFactory->createPlayerCounter(...)`
+  // followed by `initDb()` -- at any point after the table exists.
+
+  // Returns the counter with the given name.
+  public function counter(string $name): Counter
+  {
+    return $this->table()->counterFactory->localarenaGetCounter($name);
+  }
+
+  // Returns the player counter with the given name.
+  public function playerCounter(string $name): PlayerCounter
+  {
+    $counter = $this->counter($name);
+    if (!($counter instanceof PlayerCounter)) {
+      throw new \Exception('Counter "' . $name . '" is not a player counter.');
+    }
+    return $counter;
+  }
+
+  // Returns the table counter with the given name.
+  public function tableCounter(string $name): TableCounter
+  {
+    $counter = $this->counter($name);
+    if (!($counter instanceof TableCounter)) {
+      throw new \Exception('Counter "' . $name . '" is not a table counter.');
+    }
+    return $counter;
+  }
+
+  // Returns the value of the given player counter for every player it
+  // has a value for, as an array mapping the counter's own key
+  // (player id, or player no for a "useNo" counter) to value, in
+  // ascending key order.
+  //
+  // Warning: if you assert on the returned array directly, remember
+  // that PHP array comparisons can be key-order-sensitive.  Prefer
+  // `assertPlayerCounters()`, which canonicalizes both sides.
+  public function playerCounterValues(string $name): array
+  {
+    $values = $this->playerCounter($name)->getAll();
+    ksort($values);
+    return $values;
+  }
+
+  // Asserts that the given table counter has the expected value.
+  public function assertTableCounter(int $expected, string $name, string $message = ''): void
+  {
+    $this->assertSame(
+      $expected,
+      $this->tableCounter($name)->get(),
+      'Unexpected value for table counter "' . $name . '".' . ($message === '' ? '' : '  ' . $message)
+    );
+  }
+
+  // Asserts that the given player counter has the expected value for
+  // `$player`.
+  public function assertPlayerCounter(int $expected, string $name, PlayerPeer $player, string $message = ''): void
+  {
+    $this->assertSame(
+      $expected,
+      $player->counterValue($name),
+      'Unexpected value for player counter "' .
+        $name .
+        '" of player ' .
+        $player->id() .
+        '.' .
+        ($message === '' ? '' : '  ' . $message)
+    );
+  }
+
+  // Asserts that the given player counter has the expected value for
+  // every player it has a value for.  `$expected` maps the counter's
+  // own key (player id, or player no for a "useNo" counter) to the
+  // expected value; it may be in any order, but must cover every key
+  // the counter has (a key missing from `$expected` is a failure, not
+  // a "don't care").
+  public function assertPlayerCounters(array $expected, string $name, string $message = ''): void
+  {
+    $normalized = [];
+    foreach ($expected as $key => $value) {
+      $normalized[intval($key)] = $value;
+    }
+    ksort($normalized);
+    $this->assertSame(
+      $normalized,
+      $this->playerCounterValues($name),
+      'Unexpected values for player counter "' . $name . '".' . ($message === '' ? '' : '  ' . $message)
+    );
+  }
+
+  // ==================== Notifications ====================
+
+  // Returns the notifications the table has sent, oldest first, each
+  // as an array with the keys:
+  //
+  //   'id'        the gamelog id (ascending; useful for slicing)
+  //   'moveId'    the move the notification belongs to
+  //   'type'      the notification type ('setPlayerCounter', ...)
+  //   'log'       the game-log message ('' for a silent notification)
+  //   'args'      the notification's arguments
+  //   'recipient' the player it was sent to, or null for all players
+  //
+  // With `$type`, only notifications of that type are returned; with
+  // `$recipient_player_id`, only those that the given player received
+  // (which includes the ones sent to everybody).
+  public function notifs(?string $type = null, ?int $recipient_player_id = null): array
+  {
+    $rows = $this->table()->getObjectListFromDB('SELECT * FROM `gamelog` ORDER BY `gamelog_id` ASC');
+
+    $notifs = [];
+    foreach ($rows as $row) {
+      $notif = json_decode($row['gamelog_notification'], /*associative=*/ true);
+      $recipient = $row['gamelog_player'] === null ? null : intval($row['gamelog_player']);
+
+      if ($type !== null && ($notif['notification_type'] ?? null) !== $type) {
+        continue;
+      }
+      if ($recipient_player_id !== null && $recipient !== null && $recipient !== $recipient_player_id) {
+        continue;
+      }
+
+      $notifs[] = [
+        'id' => intval($row['gamelog_id']),
+        'moveId' => intval($row['gamelog_move_id']),
+        'type' => $notif['notification_type'] ?? null,
+        'log' => $notif['notification_log'] ?? null,
+        'args' => $notif['args'] ?? null,
+        'recipient' => $recipient,
+      ];
+    }
+    return $notifs;
+  }
+
   // ==================== Legacy-games data ====================
   //
   // Legacy data (the `$this->bga->legacy` API) persists ACROSS tables,
@@ -388,7 +533,10 @@ class IntegrationTestCase extends \PHPUnit\Framework\TestCase
     return json_decode($json, /*associative=*/ true);
   }
 
-  // XXX: How will we get notifs routed back to the test fix fixtures?
+  // XXX: How will we get notifs routed back to the test fixtures as
+  // they are sent?  `notifs()` above reads them back out of the
+  // gamelog after the fact, which is enough to assert on what was
+  // sent, but not to observe the sending itself.
 
   // TODO: Clean up the table after successful tests.
 }
@@ -404,6 +552,7 @@ class PlayerPeer
   // XXX: Should this be PlayerIdString?
   private string $id_;
     private int $no_;
+  private string $name_;
 
   private function table()
   {
@@ -415,6 +564,7 @@ class PlayerPeer
     $this->itc_ = $itc;
     $this->id_ = $row['player_id'];
     $this->no_ = intval($row['player_no']);
+    $this->name_ = $row['player_name'];
   }
 
   // XXX: Should this be PlayerIdString?
@@ -427,6 +577,11 @@ class PlayerPeer
     {
         return $this->no_;
     }
+
+  public function name(): string
+  {
+    return $this->name_;
+  }
 
   // XXX: This is duplicated with `CharacterPeer::act()`; do we need
   // to consolidate them?
@@ -471,6 +626,15 @@ class PlayerPeer
   public function stat(string $name): StatPeer
   {
     return new StatPeer($this->itc_, $name, $this->id_);
+  }
+
+  // Returns the value of the given player counter for this player,
+  // addressing the counter by whichever of player id and player no it
+  // is keyed by (see `setUseNo()`).
+  public function counterValue(string $name): int
+  {
+    $counter = $this->itc_->playerCounter($name);
+    return $counter->get($counter->getUseNo() ? $this->no() : intval($this->id()));
   }
   // TODO: Add accessors for things like "is this player active?"
 }

--- a/tests/CountersTest.php
+++ b/tests/CountersTest.php
@@ -1,0 +1,622 @@
+<?php declare(strict_types=1);
+
+namespace LocalArena\Test;
+
+require_once __DIR__ . '/../module/test/IntegrationTestCase.php';
+
+use Bga\GameFramework\NotificationMessage;
+use Bga\GameFramework\Components\Counters\CounterVisibility;
+use Bga\GameFramework\Components\Counters\OutOfRangeCounterException;
+use Bga\GameFramework\Components\Counters\UnknownPlayerException;
+
+/**
+ * Tests for the counter APIs: `$this->counterFactory`, the
+ * `PlayerCounter` and `TableCounter` components it creates, the two
+ * counters every game has by default (`$this->playerScore` and
+ * `$this->playerScoreAux`), and the counter helpers on the
+ * integration-test fixtures.
+ *
+ * The "localarenanoop" game creates a player counter named "credits"
+ * and a table counter named "round", takes them through the whole
+ * documented lifecycle (`initDb()` in `setupNewGame()`,
+ * `fillResult()` in `getAllDatas()`), and starts "round" at 1.  Tests
+ * that need a differently-configured counter create one themselves.
+ */
+class CountersTest extends IntegrationTestCase
+{
+    const LOCALARENA_GAME_NAME = 'localarenanoop';
+
+    private function playerId(int $index): int
+    {
+        return intval($this->playerByIndex($index)->id());
+    }
+
+    private function playerIds(): array
+    {
+        return array_map(fn($player) => intval($player->id()), $this->players());
+    }
+
+    // Returns the most recent notification of the given type.
+    private function lastNotif(string $type): array
+    {
+        $notifs = $this->notifs($type);
+        $this->assertNotEmpty($notifs, 'Expected at least one "' . $type . '" notification.');
+        return $notifs[count($notifs) - 1];
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // TableCounter
+
+    public function testTableCounterInitDbGetSetInc(): void
+    {
+        $counter = $this->table()->roundCounter;
+
+        // The game's setupNewGame() started this counter at 1.
+        $this->assertSame(1, $counter->get());
+
+        $this->assertSame(4, $counter->set(4));
+        $this->assertSame(4, $counter->get());
+
+        $this->assertSame(6, $counter->inc(2));
+        $this->assertSame(3, $counter->inc(-3));
+        $this->assertSame(3, $counter->get());
+    }
+
+    public function testTableCounterDefaultsToZero(): void
+    {
+        $counter = $this->table()->counterFactory->createTableCounter('tokens');
+        $counter->initDb();
+        $this->assertSame(0, $counter->get());
+    }
+
+    public function testTableCounterInitDbLeavesAnExistingValueAlone(): void
+    {
+        // Re-running initDb() (as an upgradeTableDb() that adds a
+        // counter to an already-published game would) must not reset
+        // the tables that already have a value.
+        $this->table()->roundCounter->set(7);
+        $this->table()->roundCounter->initDb(1);
+        $this->assertSame(7, $this->table()->roundCounter->get());
+    }
+
+    public function testTableCounterRangeIsEnforced(): void
+    {
+        $counter = $this->table()->counterFactory->createTableCounter('bounded', 0, 3);
+        $counter->initDb(1);
+
+        $this->assertSame(0, $counter->getMin());
+        $this->assertSame(3, $counter->getMax());
+
+        $this->assertSame(3, $counter->set(3));
+        $this->expectException(OutOfRangeCounterException::class);
+        $counter->inc(1);
+    }
+
+    public function testTableCounterRejectsAValueBelowTheDefaultMinimum(): void
+    {
+        // Counters have a minimum of 0 unless told otherwise.
+        $this->assertSame(0, $this->table()->roundCounter->getMin());
+        $this->expectException(OutOfRangeCounterException::class);
+        $this->table()->roundCounter->set(-1);
+    }
+
+    public function testTableCounterMayBeUnbounded(): void
+    {
+        $counter = $this->table()->counterFactory->createTableCounter('unbounded', null, null);
+        $counter->initDb();
+
+        $this->assertNull($counter->getMin());
+        $this->assertNull($counter->getMax());
+        $this->assertSame(-5, $counter->inc(-5));
+    }
+
+    public function testTableCounterReadBeforeInitDbIsAnError(): void
+    {
+        $counter = $this->table()->counterFactory->createTableCounter('uninitialized');
+        $this->expectException(\BgaVisibleSystemException::class);
+        $counter->get();
+    }
+
+    public function testTableCounterFillResult(): void
+    {
+        $result = [];
+        $this->table()->roundCounter->fillResult($result);
+        $this->assertSame(['round' => 1], $result);
+
+        $result = [];
+        $this->table()->roundCounter->fillResult($result, 'currentRound');
+        $this->assertSame(['currentRound' => 1], $result);
+    }
+
+    public function testTableCounterNotif(): void
+    {
+        $this->table()->roundCounter->set(2);
+        $this->table()->roundCounter->inc(
+            3,
+            new NotificationMessage(clienttranslate('Round ${value} of ${totalRounds}'), ['totalRounds' => 8])
+        );
+
+        $notif = $this->lastNotif('setTableCounter');
+        $this->assertSame('Round ${value} of ${totalRounds}', $notif['log']);
+        $this->assertNull($notif['recipient'], 'A table counter notification goes to every player.');
+        $this->assertSame(
+            [
+                'totalRounds' => 8,
+                'name' => 'round',
+                'value' => 5,
+                'oldValue' => 2,
+                'inc' => 3,
+                'absInc' => 3,
+            ],
+            $notif['args']
+        );
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // PlayerCounter
+
+    public function testPlayerCounterInitDbGetSetInc(): void
+    {
+        $counter = $this->table()->playerCredits;
+        $player0 = $this->playerId(0);
+        $player1 = $this->playerId(1);
+
+        // The game's setupNewGame() gave every player the default
+        // starting value.
+        $this->assertSame(0, $counter->get($player0));
+        $this->assertSame(0, $counter->get($player1));
+
+        $this->assertSame(5, $counter->set($player0, 5));
+        $this->assertSame(7, $counter->inc($player0, 2));
+        $this->assertSame(7, $counter->get($player0));
+
+        // One player's value is not another's.
+        $this->assertSame(0, $counter->get($player1));
+    }
+
+    public function testPlayerCounterInitDbWithAnInitialValue(): void
+    {
+        $counter = $this->table()->counterFactory->createPlayerCounter('energy');
+        $counter->initDb($this->playerIds(), 3);
+        $this->assertSame([$this->playerId(0) => 3, $this->playerId(1) => 3], $this->playerCounterValues('energy'));
+    }
+
+    public function testPlayerCounterGetAllAndSetAll(): void
+    {
+        $counter = $this->table()->playerCredits;
+        $counter->set($this->playerId(0), 4);
+        $counter->set($this->playerId(1), 9);
+
+        $this->assertSame([$this->playerId(0) => 4, $this->playerId(1) => 9], $counter->getAll());
+
+        $this->assertSame(2, $counter->setAll(2));
+        $this->assertSame([$this->playerId(0) => 2, $this->playerId(1) => 2], $counter->getAll());
+    }
+
+    public function testPlayerCounterRangeIsEnforced(): void
+    {
+        $counter = $this->table()->counterFactory->createPlayerCounter('bounded', 0, 3);
+        $counter->initDb($this->playerIds(), 2);
+
+        $this->expectException(OutOfRangeCounterException::class);
+        $counter->inc($this->playerId(0), 2);
+    }
+
+    public function testPlayerCounterSetAllRangeIsEnforced(): void
+    {
+        $counter = $this->table()->counterFactory->createPlayerCounter('bounded', 0, 3);
+        $counter->initDb($this->playerIds());
+
+        $this->expectException(OutOfRangeCounterException::class);
+        $counter->setAll(4);
+    }
+
+    public function testPlayerCounterRejectsAPlayerItHasNoValueFor(): void
+    {
+        $counter = $this->table()->counterFactory->createPlayerCounter('partial', 0, null, CounterVisibility::VISIBLE, /*useNo=*/ false, /*strict=*/ false);
+        // Only the first player has this counter.
+        $counter->initDb([$this->playerId(0)]);
+
+        $this->assertSame(0, $counter->get($this->playerId(0)));
+        $this->expectException(UnknownPlayerException::class);
+        $counter->get($this->playerId(1));
+    }
+
+    public function testStrictPlayerCounterRejectsAPlayerWhoIsNotAtTheTable(): void
+    {
+        // Counters validate their input by default, so a key that is
+        // not a player at the table is rejected even before we look
+        // for a stored value.
+        $this->assertTrue($this->table()->playerCredits->getStrict());
+        $this->expectException(UnknownPlayerException::class);
+        $this->table()->playerCredits->get(0);
+    }
+
+    public function testNonStrictPlayerCounterAcceptsAKeyThatIsNotAPlayer(): void
+    {
+        // The documented use for `strict: false`: a counter that also
+        // keeps a value for something that is not a player at the
+        // table, such as an automaton.
+        $counter = $this->table()->counterFactory->createPlayerCounter(
+            'automa',
+            0,
+            null,
+            CounterVisibility::VISIBLE,
+            /*useNo=*/ false,
+            /*strict=*/ false
+        );
+        $counter->initDb(array_merge($this->playerIds(), [0]));
+
+        $this->assertSame(0, $counter->get(0));
+        $this->assertSame(3, $counter->inc(0, 3));
+
+        // The counter's value for the automaton is not attributed to
+        // any player, so it does not reach `$result['players']`.
+        $result = ['players' => [$this->playerId(0) => [], $this->playerId(1) => []]];
+        $counter->fillResult($result);
+        $this->assertSame(
+            [$this->playerId(0) => ['automa' => 0], $this->playerId(1) => ['automa' => 0]],
+            $result['players']
+        );
+    }
+
+    public function testStrictnessCanBeChangedAfterCreation(): void
+    {
+        $counter = $this->table()->playerCredits;
+        $counter->setStrict(false);
+        $this->assertFalse($counter->getStrict());
+
+        // Still unknown -- just for a different reason: there is no
+        // stored value for a player the counter was not initialized
+        // with.
+        $this->expectException(UnknownPlayerException::class);
+        $counter->get(0);
+    }
+
+    public function testPlayerCounterKeyedByPlayerNo(): void
+    {
+        $counter = $this->table()->counterFactory->createPlayerCounter(
+            'byNo',
+            0,
+            null,
+            CounterVisibility::VISIBLE,
+            /*useNo=*/ true
+        );
+        $counter->initDb([1, 2]);
+
+        $this->assertTrue($counter->getUseNo());
+        $this->assertSame(4, $counter->set(1, 4));
+        $this->assertSame([1 => 4, 2 => 0], $counter->getAll());
+
+        // The test fixtures address the counter the way it is keyed.
+        $this->assertSame(4, $this->playerByIndex(0)->counterValue('byNo'));
+
+        // ... but fillResult() still keys players by player id, since
+        // that is how `$result['players']` is keyed.
+        $result = ['players' => [$this->playerId(0) => [], $this->playerId(1) => []]];
+        $counter->fillResult($result);
+        $this->assertSame(
+            [$this->playerId(0) => ['byNo' => 4], $this->playerId(1) => ['byNo' => 0]],
+            $result['players']
+        );
+    }
+
+    public function testPlayerCounterFillResult(): void
+    {
+        $this->table()->playerCredits->set($this->playerId(0), 6);
+
+        $result = ['players' => [$this->playerId(0) => ['id' => $this->playerId(0)], $this->playerId(1) => []]];
+        $this->table()->playerCredits->fillResult($result);
+        $this->assertSame(6, $result['players'][$this->playerId(0)]['credits']);
+        $this->assertSame(0, $result['players'][$this->playerId(1)]['credits']);
+
+        // A field name overrides the counter's own name.
+        $result = ['players' => [$this->playerId(0) => []]];
+        $this->table()->playerCredits->fillResult($result, 'money');
+        $this->assertSame(['money' => 6], $result['players'][$this->playerId(0)]);
+    }
+
+    public function testPlayerCounterFillResultNeedsPlayers(): void
+    {
+        $result = [];
+        $this->expectException(\BgaVisibleSystemException::class);
+        $this->table()->playerCredits->fillResult($result);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // Visibility
+
+    public function testCounterVisibilityPredicates(): void
+    {
+        $counter = $this->table()->playerCredits;
+        $this->assertTrue($counter->isVisible());
+        $this->assertFalse($counter->isSelf());
+        $this->assertFalse($counter->isHidden());
+
+        $counter->setVisibility(CounterVisibility::SELF);
+        $this->assertFalse($counter->isVisible());
+        $this->assertTrue($counter->isSelf());
+        $this->assertFalse($counter->isHidden());
+
+        $counter->setVisibility(CounterVisibility::HIDDEN);
+        $this->assertFalse($counter->isVisible());
+        $this->assertFalse($counter->isSelf());
+        $this->assertTrue($counter->isHidden());
+    }
+
+    public function testSelfCounterFillResultShowsOnlyTheViewersOwnValue(): void
+    {
+        $counter = $this->table()->playerCredits;
+        $counter->setVisibility(CounterVisibility::SELF);
+        $counter->set($this->playerId(0), 6);
+        $counter->set($this->playerId(1), 9);
+
+        $result = ['players' => [$this->playerId(0) => [], $this->playerId(1) => []]];
+        $counter->fillResult($result, /*fieldName=*/ null, /*currentPlayerId=*/ $this->playerId(1));
+        $this->assertSame(
+            [$this->playerId(0) => ['credits' => null], $this->playerId(1) => ['credits' => 9]],
+            $result['players']
+        );
+    }
+
+    public function testHiddenCounterFillResultShowsNothing(): void
+    {
+        $counter = $this->table()->playerCredits;
+        $counter->setVisibility(CounterVisibility::HIDDEN);
+        $counter->set($this->playerId(0), 6);
+
+        $result = ['players' => [$this->playerId(0) => [], $this->playerId(1) => []]];
+        $counter->fillResult($result, /*fieldName=*/ null, /*currentPlayerId=*/ $this->playerId(0));
+        $this->assertSame(
+            [$this->playerId(0) => ['credits' => null], $this->playerId(1) => ['credits' => null]],
+            $result['players']
+        );
+    }
+
+    public function testSelfCounterNotifiesOnlyTheOwningPlayer(): void
+    {
+        $counter = $this->table()->playerCredits;
+        $counter->setVisibility(CounterVisibility::SELF);
+        $counter->inc($this->playerId(1), 2);
+
+        $notif = $this->lastNotif('setPlayerCounter');
+        $this->assertSame($this->playerId(1), $notif['recipient']);
+    }
+
+    public function testHiddenCounterSendsNoNotif(): void
+    {
+        $counter = $this->table()->playerCredits;
+        $counter->setVisibility(CounterVisibility::HIDDEN);
+        $counter->inc($this->playerId(0), 2);
+        $counter->setAll(1);
+
+        $this->assertSame([], $this->notifs('setPlayerCounter'));
+        $this->assertSame([], $this->notifs('setPlayerCounterAll'));
+
+        // The value was still stored; it is just not announced.
+        $this->assertSame(1, $counter->get($this->playerId(0)));
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // Notifications
+
+    public function testPlayerCounterNotifArgs(): void
+    {
+        $this->table()->playerCredits->set($this->playerId(0), 5);
+        $this->table()->playerCredits->inc(
+            $this->playerId(0),
+            -2,
+            new NotificationMessage(clienttranslate('${player_name} loses ${absInc} credits playing ${card_name}'), [
+                'card_name' => 'Hunter',
+            ])
+        );
+
+        $notif = $this->lastNotif('setPlayerCounter');
+        $this->assertNull($notif['recipient'], 'A public counter notification goes to every player.');
+        $this->assertSame('${player_name} loses ${absInc} credits playing ${card_name}', $notif['log']);
+        $this->assertSame(
+            [
+                'card_name' => 'Hunter',
+                'name' => 'credits',
+                'value' => 3,
+                'oldValue' => 5,
+                'inc' => -2,
+                'absInc' => 2,
+                'playerId' => $this->playerId(0),
+                'player_name' => $this->playerByIndex(0)->name(),
+            ],
+            $notif['args']
+        );
+    }
+
+    public function testCounterNotifDefaultsToNoLogMessage(): void
+    {
+        $this->table()->playerCredits->inc($this->playerId(0), 1);
+
+        $notif = $this->lastNotif('setPlayerCounter');
+        $this->assertSame('', $notif['log'], 'By default a counter update is announced but not logged.');
+        $this->assertSame(1, $notif['args']['value']);
+    }
+
+    public function testANullMessageSendsNoNotifAtAll(): void
+    {
+        $this->table()->playerCredits->inc($this->playerId(0), 1, null);
+        $this->table()->roundCounter->inc(1, null);
+        $this->table()->playerCredits->setAll(3, null);
+
+        $this->assertSame([], $this->notifs('setPlayerCounter'));
+        $this->assertSame([], $this->notifs('setTableCounter'));
+        $this->assertSame([], $this->notifs('setPlayerCounterAll'));
+
+        // The values were still updated.
+        $this->assertSame(3, $this->table()->playerCredits->get($this->playerId(0)));
+        $this->assertSame(2, $this->table()->roundCounter->get());
+    }
+
+    public function testAnIncrementOfZeroSendsNoNotif(): void
+    {
+        $this->table()->playerCredits->set($this->playerId(0), 4);
+        $this->assertSame(4, $this->table()->playerCredits->inc($this->playerId(0), 0));
+        $this->assertSame(1, $this->table()->roundCounter->inc(0));
+
+        // Only the set() above was announced.
+        $this->assertCount(1, $this->notifs('setPlayerCounter'));
+        $this->assertSame([], $this->notifs('setTableCounter'));
+    }
+
+    public function testSetAllNotif(): void
+    {
+        $this->table()->playerCredits->setAll(4, new NotificationMessage(clienttranslate('Everyone gets 4 credits')));
+
+        $notif = $this->lastNotif('setPlayerCounterAll');
+        $this->assertNull($notif['recipient']);
+        $this->assertSame('Everyone gets 4 credits', $notif['log']);
+        $this->assertSame(['name' => 'credits', 'value' => 4], $notif['args']);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // The default score counters
+
+    public function testPlayerScoreWritesThePlayerTable(): void
+    {
+        $score = $this->table()->playerScore;
+
+        // No initDb() call is needed: every player at the table has a
+        // score from the moment they are seated.
+        $this->assertSame(0, $score->get($this->playerId(0)));
+
+        $this->assertSame(4, $score->set($this->playerId(0), 4));
+        $this->assertSame(
+            4,
+            intval(
+                $this->table()->getUniqueValueFromDB(
+                    'SELECT `player_score` FROM `player` WHERE `player_id` = ' . $this->playerId(0)
+                )
+            )
+        );
+
+        $this->assertSame(1, $score->inc($this->playerId(0), -3));
+        $this->assertSame([$this->playerId(0) => 1, $this->playerId(1) => 0], $score->getAll());
+    }
+
+    public function testPlayerScoreAuxWritesItsOwnColumn(): void
+    {
+        $this->table()->playerScoreAux->set($this->playerId(0), 7);
+
+        $this->assertSame(7, $this->table()->playerScoreAux->get($this->playerId(0)));
+        $this->assertSame(
+            7,
+            intval(
+                $this->table()->getUniqueValueFromDB(
+                    'SELECT `player_score_aux` FROM `player` WHERE `player_id` = ' . $this->playerId(0)
+                )
+            )
+        );
+
+        // The two counters are independent.
+        $this->assertSame(0, $this->table()->playerScore->get($this->playerId(0)));
+    }
+
+    public function testPlayerScoreSetAll(): void
+    {
+        $this->assertSame(2, $this->table()->playerScore->setAll(2));
+        $this->assertSame([$this->playerId(0) => 2, $this->playerId(1) => 2], $this->table()->playerScore->getAll());
+    }
+
+    public function testPlayerScoreIsUnboundedAndNotStrict(): void
+    {
+        $score = $this->table()->playerScore;
+        $this->assertNull($score->getMin());
+        $this->assertNull($score->getMax());
+        $this->assertFalse($score->getStrict());
+
+        // In particular, a score may go negative.
+        $this->assertSame(-3, $score->inc($this->playerId(0), -3));
+    }
+
+    public function testPlayerScoreNotif(): void
+    {
+        $this->table()->playerScore->inc(
+            $this->playerId(0),
+            2,
+            new NotificationMessage(clienttranslate('${player_name} scores ${inc} points'))
+        );
+
+        $notif = $this->lastNotif('setPlayerCounter');
+        $this->assertSame('playerScore', $notif['args']['name']);
+        $this->assertSame(2, $notif['args']['value']);
+        $this->assertSame($this->playerId(0), $notif['args']['playerId']);
+    }
+
+    public function testPlayerScoreIsPublishedAsTheScoreField(): void
+    {
+        // The front-end score counter reads "score", which is how
+        // games are expected to publish `player_score` from
+        // `getAllDatas()`.
+        $this->table()->playerScore->set($this->playerId(0), 11);
+
+        $result = ['players' => [$this->playerId(0) => [], $this->playerId(1) => []]];
+        $this->table()->playerScore->fillResult($result, 'score');
+        $this->assertSame(
+            [$this->playerId(0) => ['score' => 11], $this->playerId(1) => ['score' => 0]],
+            $result['players']
+        );
+    }
+
+    public function testCounterValuesReachTheClientThroughGetAllDatas(): void
+    {
+        // The game's getAllDatas() calls fillResult() on both of its
+        // counters, so their values are in the gamedatas the client
+        // is served.
+        $this->table()->roundCounter->set(3);
+        $this->table()->playerCredits->set($this->playerId(0), 6);
+
+        $alldatas = $this->gamedatas()['alldatas'];
+        $this->assertSame(3, $alldatas['round']);
+        $this->assertSame(6, $alldatas['players'][$this->playerId(0)]['credits']);
+
+        // ... alongside the framework's own information about the
+        // player.
+        $this->assertSame($this->playerByIndex(0)->name(), $alldatas['players'][$this->playerId(0)]['name']);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // The factory
+
+    public function testCountersAreLookedUpByName(): void
+    {
+        $this->assertSame($this->table()->playerCredits, $this->counter('credits'));
+        $this->assertSame($this->table()->roundCounter, $this->counter('round'));
+        $this->assertSame($this->table()->playerScore, $this->counter('playerScore'));
+        $this->assertSame($this->table()->playerScoreAux, $this->counter('playerScoreAux'));
+    }
+
+    public function testCounterNamesMustBeUnique(): void
+    {
+        $this->expectException(\BgaVisibleSystemException::class);
+        $this->table()->counterFactory->createTableCounter('credits');
+    }
+
+    public function testUnknownCounterNameIsAnError(): void
+    {
+        $this->expectException(\BgaVisibleSystemException::class);
+        $this->counter('nosuchcounter');
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // The test fixtures
+
+    public function testCounterAssertionHelpers(): void
+    {
+        $this->table()->roundCounter->set(3);
+        $this->table()->playerCredits->set($this->playerId(0), 5);
+        $this->table()->playerCredits->set($this->playerId(1), 8);
+
+        $this->assertTableCounter(3, 'round');
+        $this->assertPlayerCounter(5, 'credits', $this->playerByIndex(0));
+        $this->assertPlayerCounter(8, 'credits', $this->playerByIndex(1));
+
+        // Order-insensitive, and covers every player.
+        $this->assertPlayerCounters([$this->playerId(1) => 8, $this->playerId(0) => 5], 'credits');
+    }
+}


### PR DESCRIPTION
Implements the BGA counter framework components for LocalArena, allowing games to create and manage player and table counters with automatic front-end synchronization via notifications.

## Summary

This PR adds full support for BGA's counter system, which provides a framework for games to track and publish integer values (player money, round numbers, etc.). Counters automatically notify the front end of changes, keeping UI elements in sync without manual intervention.

## Key Changes

- **LocalArenaCounters.php**: Core counter implementation
  - `Counter` base class with name validation, range checking, and notification argument generation
  - `TableCounter` for single values shared across the table (stored in `bga_table_counters`)
  - `PlayerCounter` for per-player values with visibility controls (stored in `bga_player_counters`)
  - `CounterVisibility` enum (VISIBLE, SELF, HIDDEN) controlling who sees each player's values
  - `LocalArenaPlayerCounterStore` abstraction for flexible storage backends
  - Support for player-id or player-no keying, strict/non-strict validation, and custom initial values

- **NotificationMessage.php**: Message wrapper for counter updates
  - Carries log message and extra arguments alongside counter notifications
  - Supports null messages (notification without log entry) and null parameter (no notification)

- **CounterFactory integration** (table.game.php)
  - `$this->counterFactory` factory for creating counters
  - `$this->playerScore` and `$this->playerScoreAux` default counters (stored in `player` table, no `initDb()` needed)

- **Front-end counter updates** (counter.ts, gamegui.ts)
  - `EbgCounter.create()` now accepts `playerCounter`/`tableCounter` options to auto-sync from server
  - Counters subscribe to `setPlayerCounter`/`setTableCounter`/`setPlayerCounterAll` notifications
  - Score controls automatically follow `playerScore` counter

- **Test support** (IntegrationTestCase.php, CountersTest.php)
  - Helper methods: `counter()`, `playerCounter()`, `tableCounter()`, `playerCounterValues()`
  - Assertions: `assertTableCounter()`, `assertPlayerCounter()`, `assertPlayerCounters()`
  - Comprehensive test suite covering initialization, get/set/inc, ranges, visibility, player keying, and strictness

- **Database schema** (empty_database.sql)
  - Drop statements for `bga_player_counters` and `bga_table_counters` tables

- **Documentation** (README.md)
  - Usage examples and API overview for tests

## Notable Implementation Details

- **LocalArena divergences** (intentional, documented in code):
  - Reading an uninitialized counter throws an error rather than silently returning zero
  - Duplicate counter names are rejected
  - Hidden counters don't send redacted notifications to restricted viewers
  
- **Visibility handling**: `fillResult()` respects visibility settings, filling null for values the viewer cannot see (displays "-" on front end)

- **Player keying flexibility**: Counters can use player IDs or player numbers; `fillResult()` always keys by player ID for consistency with `$result['players']` structure

- **Strictness option**: Allows counters to hold values for non-player keys (e.g., automaton with ID 0) when `strict: false`

- **Storage abstraction**: `LocalArenaPlayerCounterStore` enables different backends (table-based vs. column-based for default counters)

https://claude.ai/code/session_0191vDx2aXRotTG9HxefnehP