### PR TITLE
Fix inverted bExclusive semantics in setPlayersMultiactive()

### DIFF
--- a/src/module/table/GameState.php
+++ b/src/module/table/GameState.php
@@ -89,19 +89,33 @@ class GameState
   /**
    * Activate each of the players in $players.
    *
-   * If `!$bExclusive`, any players not in $players will be deactivated.
+   * $bExclusive says what happens to players who are already
+   * multiactive but are NOT in $players:
    *
-   * If no players are active afterwards, the state transition
-   * $next_state will be taken.
+   * - false (the default): they stay active, i.e. $players is ADDED to
+   *   the set of active players;
+   * - true: they are deactivated, so that the players multiactive at
+   *   the end are exactly those in $players.
+   *
+   * Whether the $next_state transition is taken depends on the
+   * ARGUMENT, not on the resulting flags: with a non-empty $players,
+   * $next_state is ignored entirely (whatever is passed for it); with
+   * an empty $players, the transition is taken.  Note that this means
+   * an empty $players and `!$bExclusive` transitions onwards even
+   * though the players who were already active still carry the flag.
+   *
+   * Returns true iff the state transition was taken.
    *
    * @param $players
    * @param $next_state
    * @param $bExclusive
    */
-  public function setPlayersMultiactive($players, $next_state, bool $bExclusive = false)
+  public function setPlayersMultiactive($players, $next_state, bool $bExclusive = false): bool
   {
-    if (!$bExclusive) {
-      // Deactivate all players (those in $players will be reactivated below)
+    if ($bExclusive) {
+      // Deactivate all players (those in $players are reactivated
+      // below), so that $players ends up being exactly the multiactive
+      // set.
       $this->game->DbQuery('UPDATE `player` SET `player_is_multiactive` = 0');
     }
 
@@ -114,10 +128,12 @@ class GameState
     // notif even if $players is empty.
     $this->game->notify_gameStateMultipleActiveUpdate();
 
-    // Transition if no players are active afterwards
-    if ($this->game->getUniqueValueFromDB('SELECT COUNT(*) FROM `player` WHERE `player_is_multiactive` = 1') == 0) {
+    if (count($players) == 0) {
       $this->nextState($next_state);
+      return true;
     }
+
+    return false;
   }
 
   /**

--- a/tests/SetPlayersMultiactiveTest.php
+++ b/tests/SetPlayersMultiactiveTest.php
@@ -1,0 +1,290 @@
+<?php declare(strict_types=1);
+
+namespace LocalArena\Test;
+
+require_once __DIR__ . '/../module/test/IntegrationTestCase.php';
+
+// We extend the bundled "localarenanoop" harness game, so load its
+// class.  When a test supplies a `table_class`, TableManager::getTable()
+// instantiates that class directly and does NOT require the game's
+// .game.php file, so we must require it ourselves before subclassing.
+require_once LOCALARENA_GAME_PATH . 'localarenanoop/localarenanoop.game.php';
+
+/**
+ * Tests for `$this->gamestate->setPlayersMultiactive($players,
+ * $next_state, $bExclusive)`.
+ *
+ * The two things this method decides are independent of each other, and
+ * both are easy to get backwards:
+ *
+ * - WHO ends up active.  $players is always activated; $bExclusive says
+ *   what happens to everyone else.  False (the default) leaves players
+ *   who were already multiactive active -- $players is added to them --
+ *   while true deactivates them, so the multiactive set ends up being
+ *   exactly $players.
+ *
+ * - WHETHER the machine moves on.  That is driven by the ARGUMENT, not
+ *   by the flags the call leaves behind: a non-empty $players ignores
+ *   $next_state entirely, and an empty one takes the transition.
+ */
+class SetPlayersMultiactiveTest extends IntegrationTestCase
+{
+    const LOCALARENA_GAME_NAME = 'localarenanoop';
+
+    const ST_MULTI = 20;  // multipleactiveplayer; where these tests run
+    const ST_DONE = 21;   // where "tDone" leads
+
+    protected function defaultTableParams(): \LocalArena\TableParams
+    {
+        $params = parent::defaultTableParams();
+        // Three players, so that "the others" is more than one player
+        // and an exclusive call has something to deactivate besides the
+        // player it activates.
+        $params->playerCount = 3;
+        $params->table_class = SetPlayersMultiactiveTestGame::class;
+        return $params;
+    }
+
+    private function game(): SetPlayersMultiactiveTestGame
+    {
+        return $this->table();
+    }
+
+    // The player ids, in seating order.
+    private function playerId(int $index): int
+    {
+        return intval($this->playerByIndex($index)->id());
+    }
+
+    // The multiactive players, as ints and in a stable order, so that
+    // they can be compared against an expected set.
+    private function activeIds(): array
+    {
+        $ids = array_map('intval', $this->game()->gamestate->getActivePlayerList());
+        sort($ids);
+        return $ids;
+    }
+
+    // Makes exactly $player_ids multiactive, without going through the
+    // method under test.
+    private function givenMultiactive(array $player_ids): void
+    {
+        $game = $this->game();
+        $game->DbQuery('UPDATE `player` SET `player_is_multiactive` = 0');
+        if (count($player_ids) > 0) {
+            $game->DbQuery(
+                'UPDATE `player` SET `player_is_multiactive` = 1 WHERE `player_id` IN (' .
+                    implode(',', $player_ids) .
+                    ')'
+            );
+        }
+    }
+
+    /**
+     * The default (and `$bExclusive` false) is ADDITIVE: players who
+     * were already multiactive stay that way.
+     */
+    public function testNonExclusiveAddsToTheAlreadyActivePlayers(): void
+    {
+        $this->givenMultiactive([$this->playerId(0)]);
+
+        $this->game()->gamestate->setPlayersMultiactive(
+            [$this->playerId(1)],
+            'tDone',
+            /*bExclusive=*/ false
+        );
+
+        $expected = [$this->playerId(0), $this->playerId(1)];
+        sort($expected);
+        $this->assertEquals(
+            $expected,
+            $this->activeIds(),
+            'A non-exclusive call must not deactivate players who were already active.'
+        );
+        $this->assertGameState(self::ST_MULTI);
+    }
+
+    /**
+     * Omitting $bExclusive is the same as passing false -- so the
+     * default is the additive case, NOT the exclusive one.
+     */
+    public function testDefaultsToNonExclusive(): void
+    {
+        $this->givenMultiactive([$this->playerId(0)]);
+
+        $this->game()->gamestate->setPlayersMultiactive([$this->playerId(1)], 'tDone');
+
+        $expected = [$this->playerId(0), $this->playerId(1)];
+        sort($expected);
+        $this->assertEquals($expected, $this->activeIds());
+    }
+
+    /**
+     * With $bExclusive true, the players multiactive afterwards are
+     * exactly those named: everyone else is deactivated.
+     */
+    public function testExclusiveDeactivatesTheOtherPlayers(): void
+    {
+        $this->givenMultiactive([$this->playerId(0), $this->playerId(2)]);
+
+        $this->game()->gamestate->setPlayersMultiactive(
+            [$this->playerId(1)],
+            'tDone',
+            /*bExclusive=*/ true
+        );
+
+        $this->assertEquals(
+            [$this->playerId(1)],
+            $this->activeIds(),
+            'An exclusive call must leave exactly the named players active.'
+        );
+        $this->assertGameState(self::ST_MULTI);
+    }
+
+    /**
+     * An exclusive call activates the named players even if they were
+     * not active before, and keeps those of them that already were:
+     * "exactly $players" cuts both ways.
+     */
+    public function testExclusiveActivatesExactlyTheNamedPlayers(): void
+    {
+        $this->givenMultiactive([$this->playerId(0)]);
+
+        $this->game()->gamestate->setPlayersMultiactive(
+            [$this->playerId(0), $this->playerId(2)],
+            'tDone',
+            /*bExclusive=*/ true
+        );
+
+        $expected = [$this->playerId(0), $this->playerId(2)];
+        sort($expected);
+        $this->assertEquals($expected, $this->activeIds());
+    }
+
+    /**
+     * With a non-empty $players the transition is NOT taken, however
+     * many players are active before or after -- $next_state is ignored
+     * entirely, so it need not even name a valid transition.
+     */
+    public function testDoesNotTransitionWhenPlayersIsNotEmpty(): void
+    {
+        $this->givenMultiactive([]);
+
+        $transitioned = $this->game()->gamestate->setPlayersMultiactive(
+            [$this->playerId(1)],
+            'tThisTransitionDoesNotExist',
+            /*bExclusive=*/ true
+        );
+
+        $this->assertFalse($transitioned);
+        $this->assertGameState(
+            self::ST_MULTI,
+            'A call naming players must stay put, whatever was passed for $next_state.'
+        );
+    }
+
+    /**
+     * An empty $players takes the transition.  Being exclusive, it also
+     * leaves nobody active -- which is the usual way a state is left
+     * when it turns out there is nothing for anyone to do.
+     */
+    public function testEmptyPlayersExclusiveDeactivatesEveryoneAndTransitions(): void
+    {
+        $this->givenMultiactive([$this->playerId(0), $this->playerId(1)]);
+
+        $transitioned = $this->game()->gamestate->setPlayersMultiactive(
+            [],
+            'tDone',
+            /*bExclusive=*/ true
+        );
+
+        $this->assertTrue($transitioned);
+        $this->assertGameState(self::ST_DONE);
+        $this->assertEquals(
+            0,
+            intval(
+                $this->game()->getUniqueValueFromDB(
+                    'SELECT COUNT(*) FROM `player` WHERE `player_is_multiactive` = 1'
+                )
+            ),
+            'An exclusive call with no players must leave nobody multiactive.'
+        );
+    }
+
+    /**
+     * An empty $players takes the transition even when the call is
+     * non-exclusive and so leaves players carrying the multiactive
+     * flag: it is the empty argument that moves the machine, not the
+     * absence of active players.
+     */
+    public function testEmptyPlayersNonExclusiveTransitionsAnyway(): void
+    {
+        $this->givenMultiactive([$this->playerId(0)]);
+
+        $transitioned = $this->game()->gamestate->setPlayersMultiactive(
+            [],
+            'tDone',
+            /*bExclusive=*/ false
+        );
+
+        $this->assertTrue($transitioned);
+        $this->assertGameState(self::ST_DONE);
+        $this->assertEquals(
+            1,
+            intval(
+                $this->game()->getUniqueValueFromDB(
+                    'SELECT COUNT(*) FROM `player` WHERE `player_is_multiactive` = 1'
+                )
+            ),
+            'A non-exclusive call must not clear the flags of players who were already active.'
+        );
+    }
+}
+
+/**
+ * A localarenanoop subclass whose only job is to install a state
+ * machine that starts in a multiactive state, so that
+ * `setPlayersMultiactive()` can be called there and the state it
+ * transitions to can be observed.  Used only by
+ * SetPlayersMultiactiveTest.
+ */
+class SetPlayersMultiactiveTestGame extends \localarenanoop
+{
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->gamestate = new \GameState($this, self::multiactiveMachineStates());
+    }
+
+    private static function multiactiveMachineStates(): array
+    {
+        return [
+            // Initial state; base Table::stGameSetup() runs here and
+            // transitions straight into the multiactive state.
+            1 => [
+                'name' => 'gameSetup',
+                'description' => '',
+                'type' => 'manager',
+                'action' => 'stGameSetup',
+                'transitions' => ['' => SetPlayersMultiactiveTest::ST_MULTI],
+            ],
+
+            SetPlayersMultiactiveTest::ST_MULTI => [
+                'name' => 'stMulti',
+                'description' => '',
+                'type' => 'multipleactiveplayer',
+                'possibleactions' => [],
+                'transitions' => ['tDone' => SetPlayersMultiactiveTest::ST_DONE],
+            ],
+
+            SetPlayersMultiactiveTest::ST_DONE => [
+                'name' => 'stDone',
+                'description' => '',
+                'type' => 'activeplayer',
+                'possibleactions' => [],
+                'transitions' => [],
+            ],
+        ];
+    }
+}

--- a/tests/SetPlayersMultiactiveTest.php
+++ b/tests/SetPlayersMultiactiveTest.php
@@ -37,10 +37,11 @@ class SetPlayersMultiactiveTest extends IntegrationTestCase
     protected function defaultTableParams(): \LocalArena\TableParams
     {
         $params = parent::defaultTableParams();
-        // Three players, so that "the others" is more than one player
-        // and an exclusive call has something to deactivate besides the
-        // player it activates.
-        $params->playerCount = 3;
+        // N.B.: The harness seats LOCALARENA_PLAYER_COUNT players
+        // whatever `TableParams::$playerCount` says, so these tests are
+        // written for the two players it gives us: in each of them one
+        // player stands for "the players named in the call" and the
+        // other for "everyone else".
         $params->table_class = SetPlayersMultiactiveTestGame::class;
         return $params;
     }
@@ -125,7 +126,7 @@ class SetPlayersMultiactiveTest extends IntegrationTestCase
      */
     public function testExclusiveDeactivatesTheOtherPlayers(): void
     {
-        $this->givenMultiactive([$this->playerId(0), $this->playerId(2)]);
+        $this->givenMultiactive([$this->playerId(0), $this->playerId(1)]);
 
         $this->game()->gamestate->setPlayersMultiactive(
             [$this->playerId(1)],
@@ -142,23 +143,21 @@ class SetPlayersMultiactiveTest extends IntegrationTestCase
     }
 
     /**
-     * An exclusive call activates the named players even if they were
-     * not active before, and keeps those of them that already were:
-     * "exactly $players" cuts both ways.
+     * "Exactly $players" cuts both ways: an exclusive call activates a
+     * named player who was not active before, in the same breath as it
+     * deactivates an unnamed player who was.
      */
-    public function testExclusiveActivatesExactlyTheNamedPlayers(): void
+    public function testExclusiveActivatesTheNamedPlayerAndDeactivatesTheRest(): void
     {
         $this->givenMultiactive([$this->playerId(0)]);
 
         $this->game()->gamestate->setPlayersMultiactive(
-            [$this->playerId(0), $this->playerId(2)],
+            [$this->playerId(1)],
             'tDone',
             /*bExclusive=*/ true
         );
 
-        $expected = [$this->playerId(0), $this->playerId(2)];
-        sort($expected);
-        $this->assertEquals($expected, $this->activeIds());
+        $this->assertEquals([$this->playerId(1)], $this->activeIds());
     }
 
     /**


### PR DESCRIPTION
## The bug

BGA's documentation for `setPlayersMultiactive($players, $next_state, $bExclusive)`:

> If "bExclusive" parameter is not set or false it doesn't deactivate other previously active players. If it's set to true, the players who will be multiactive at the end are only these in "$players" array.

We had the condition the other way around: `if (!$bExclusive)` cleared every player's multiactive flag, so the default (`false`) was the *exclusive* case and `true` was the additive one. The docblock stated the inverted rule as well, so code and comment agreed with each other and both disagreed with BGA.

## Also fixed: what drives the transition

BGA drives the `$next_state` transition off the *argument*, not off the resulting flags:

- non-empty `$players` → the transition is not taken and `$next_state` is ignored entirely;
- empty `$players` → the transition is taken.

We instead re-queried the `player` table afterwards and transitioned only when nobody was left multiactive. Post-exclusivity-fix those agree everywhere except one case — empty `$players` with `$bExclusive` false, where the players who were already active survive the call, so BGA moves on and we would have stayed put. The method now also returns whether the transition happened, matching the signature in `_ide_helper.php` (it previously returned nothing).

## Caller impact

The one caller in the tree is BurgleBrosTwo's `stCharacterSelection()`, which passes `/*bExclusive=*/ true` with BGA's meaning in mind, so it is fixed rather than broken by this change. Two latent bugs there go away: players who had passed in an earlier selection round could stay multiactive on re-entry to the state, and an empty `$players_not_passed` left the state hanging instead of taking `tRoundDone`.

## Tests

New `tests/SetPlayersMultiactiveTest.php` runs in a `multipleactiveplayer` state and covers the two independent decisions the method makes:

- who ends up active — additive, additive-by-default, exclusive-deactivates-others, exclusive-activates-the-named-player-and-deactivates-the-rest;
- whether the machine moves on — non-empty `$players` stays put (asserted by passing a `$next_state` that is not even a valid transition), empty `$players` transitions both with and without exclusivity, with the flag side effects checked in each case.

The tests are written for the two players the harness seats (`LOCALARENA_PLAYER_COUNT`, which `TableParams::$playerCount` does not override): in each case one player stands for "the players named in the call" and the other for "everyone else".

Docker isn't available in the environment this was written in, so the suite was not run locally — relying on CI for the results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vj4smKUaPwzw8LAtRVcfug