### PR TITLE
Keep the testenv build cache warm; retry Composer downloads

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,61 @@
+name: Warm testenv build cache
+
+# The `build` job in `test:server` restores the testenv image layers from
+# the GitHub Actions cache (`cache-from: type=gha`). Those entries are
+# scoped per ref, and GitHub evicts anything that has not been *accessed*
+# for 7 days. So after a quiet week on main, the next push rebuilds the
+# image from scratch and has to re-download every Composer package over
+# the network.
+#
+# That is exactly how run 31894604833 failed: main's cache had gone cold
+# (the previous main build was 18 days earlier), the `composer require`
+# layers actually executed, api.github.com returned HTTP 504 for four
+# package zipballs, and the image build died -- so all 8 test shards were
+# skipped without a single test running.
+#
+# Scheduled workflows always run on the default branch, which means this
+# job reads and writes the very cache scope that push-to-main builds
+# depend on. Pull requests benefit too, since a PR can read its base
+# branch's cache.
+#
+# When the cache is already warm this is a no-op: every layer is a cache
+# hit, nothing is downloaded, and the run just refreshes the eviction
+# clock.
+#
+# Note that GitHub disables scheduled workflows in repositories with no
+# activity for 60 days; if that ever happens, re-enable this from the
+# Actions tab (or trigger it via workflow_dispatch).
+
+on:
+  schedule:
+    # Daily, comfortably inside the 7-day eviction window.
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+# Never let a manual dispatch race the scheduled run: they would both be
+# writing the same cache scope.
+concurrency:
+  group: cache-warm
+  cancel-in-progress: false
+
+jobs:
+  warm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # These inputs must mirror the `build` job in `tests.yml` -- same
+      # context, same target, same (default) gha cache scope -- otherwise
+      # this warms cache entries that `build` will never look up. There is
+      # deliberately no `load:`/`push:`, since nothing here needs the
+      # image itself; only the exported layer cache matters.
+      - name: Build testenv image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: testenv
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,9 +104,45 @@ RUN apt-get update -y && apt-get dist-upgrade -y \
     && apt-get install --no-install-recommends --yes p7zip-full default-mysql-client \
     && rm -rf /var/lib/apt/lists/*
 
-RUN composer require --dev phpunit/phpunit ^11
-RUN composer require --dev brianium/paratest:${PARATEST_VERSION}
-RUN composer require --dev phan/phan:${PHAN_VERSION}
+# Composer fetches package zipballs from api.github.com, which
+# intermittently returns 5xx. Source fallback is disabled for
+# non-interactive installs ("Not trying alternative sources"), so a single
+# 504 aborts the image build -- and since CI builds this image before it
+# can run anything, that takes down the whole test suite. Retry with
+# backoff instead.
+#
+# The three requires share one layer so they also share the retry helper;
+# they were previously three layers, but they are always invalidated
+# together anyway.
+#
+# ARGs in scope are exported into the RUN environment, so the quoted
+# heredoc below (no Dockerfile-level expansion, which would eat the shell
+# variables) still interpolates the pinned versions.
+RUN <<'EOF'
+set -eu
+
+composer_require() {
+    attempt=1
+    while :; do
+        if composer require --dev --no-interaction "$@"; then
+            return 0
+        fi
+        if [ "${attempt}" -ge 5 ]; then
+            echo "composer require $* failed after 5 attempts" >&2
+            return 1
+        fi
+        delay=$((attempt * 10))
+        echo "composer require $* failed (attempt ${attempt}/5); retrying in ${delay}s" >&2
+        sleep "${delay}"
+        attempt=$((attempt + 1))
+    done
+}
+
+composer_require phpunit/phpunit ^11
+composer_require brianium/paratest:${PARATEST_VERSION}
+composer_require phan/phan:${PHAN_VERSION}
+EOF
+
 ENV PATH="$PATH:/vendor/bin"
 
 ENV DB_HOST=db


### PR DESCRIPTION
## What went wrong on main

[Run 31894604833](https://github.com/wardcanyon/localarena/actions/runs/31894604833) on `0cd919d8` is red, but **no test failed — and none ran.** The `build` job died and all 8 shards were skipped:

```
Dockerfile:107  RUN composer require --dev phpunit/phpunit ^11

Failed to download phpunit/php-file-iterator from dist: The
"https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64..."
file could not be downloaded (HTTP/2 504 )
Source fallback is disabled. Not trying alternative sources.
```

Four packages 504'd, Composer exited 100, buildx failed, and the `test:server` gate job reported "One or more jobs failed". `Build and push image` was correctly skipped, so GHCR still holds the image from 2026-07-28.

## Why it passed as a PR and failed on main

Not timing — a cache-scope asymmetry. Both jobs use `cache-from: type=gha`, and Actions caches are scoped per ref:

- **PR run** (16:04) imported manifest `gha:986744595177509730` and got a full hit — every layer through `#21 [testenv 7/17] RUN composer require --dev phpunit/phpunit ^11` logged `CACHED`. It never touched the network for Composer.
- **Push-to-main run** (16:07) imported a different manifest, `gha:8582120959629600752`, with **zero** `CACHED` layers. The previous successful main build was 2026-07-28 — 18 days back, well past GitHub's 7-day eviction window — so main's scope was cold and the Composer layers actually executed.

The PR was green because it never ran the fragile step. Any push to main following a gap longer than the eviction window would have hit this, regardless of the diff.

## Changes

**`.github/workflows/cache-warm.yml`** (new) — a daily job that rebuilds the `testenv` target with `cache-from`/`cache-to: type=gha`. Scheduled workflows always run on the default branch, so this reads and writes exactly the scope that push-to-main builds depend on, and that PRs inherit from their base branch. Its inputs mirror the `test:server` `build` job (same context, same target, same default gha scope) so the entries it writes are the ones that job looks up. When the cache is already warm every layer hits, nothing downloads, and the run just refreshes the eviction clock.

**`Dockerfile`** — `composer require` now runs through a bounded retry with backoff (5 attempts, 10s/20s/30s/40s), so a transient 5xx no longer aborts the build on the occasions the cache genuinely is cold. Source fallback is disabled for non-interactive installs, which is why one 504 was previously fatal. The three requires share a layer now; they were always invalidated together anyway.

The two are complementary: warming means the network path is rarely taken, retrying means it survives when it is.

## Testing

No Docker daemon in this environment, so per `CLAUDE.md` the suite runs in CI. Two things make that a real check rather than a formality:

- The Dockerfile change invalidates the Composer layers, so this PR's build performs an actual Composer install over the network — exercising the new retry path end to end and confirming the BuildKit heredoc parses.
- The retry helper was extracted from the Dockerfile and run under `/bin/sh` against a stubbed `composer`: success on first attempt, success after two 504s, and failure after all 5 attempts (exit 1, propagated by `set -e`). Pinned `ARG` versions interpolate correctly inside the quoted heredoc, since ARGs in scope are exported into the `RUN` environment.

Worth noting `cache-warm.yml` cannot be verified until it is on the default branch — `schedule` only fires there.

## Follow-up

Main is still red on `0cd919d8` from the transient failure. Re-running that workflow should clear it; I lacked `actions: write` to trigger it (`403 Resource not accessible by integration`).

---
_Generated by [Claude Code](https://claude.ai/code/session_0111JRAmiz3XNq6bAgRm3uto)_