### PR TITLE
Add a unit-test lane, and fix getArg()'s optional arguments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,27 +2,50 @@
 
 ## Running the test suite
 
-The PHPUnit integration tests require Docker: a `testenv` image plus a
-running MySQL `db` service on the `localarena_default` network (see
-`Gruntfile.cjs`'s `shell:test` task and `compose.yaml`). Locally, the
-suite is normally run with `grunt test` (which builds the `testenv`
-image and runs `phpunit` against `tests/phpunit.xml`).
+The suite has two lanes, which differ in what they need to run:
+
+- **Integration tests** (`tests/*Test.php`) create a real table in a
+  real database, and so require Docker: a `testenv` image plus a
+  running MySQL `db` service on the `localarena_default` network (see
+  `Gruntfile.cjs`'s `shell:test` task and `compose.yaml`). Locally,
+  they are normally run with `grunt test` (which builds the `testenv`
+  image and runs `phpunit` against `tests/phpunit.xml`).
+
+- **Unit tests** (`tests/unit/*Test.php`) exercise framework code in
+  isolation -- no table, no database, no Docker. They need only a PHP
+  interpreter and PHPUnit. See `tests/unit/UnitTestCase.php`.
+
+Both lanes are collected by `tests/phpunit.xml` and sharded by CI
+together, so `grunt test` runs everything.
 
 ### Claude Code Remote (web) sessions
 
 The guidance below applies **only** when running in a Claude Code Remote
 execution environment (e.g. a Claude Code on the web session), where the
 Docker daemon and image registry are **not** reliably available (image
-pulls are blocked by the network policy), so the suite generally
-**cannot be run in the sandbox**.
+pulls are blocked by the network policy), so the **integration** lane
+generally **cannot be run in the sandbox**.
 
-In that case, **do not** rely on running the tests in the sandbox.
-Instead, push the branch, wait for a PR to be opened, and examine the
-**CI** state for the test results. Investigate and address CI failures
-from there.
+For integration tests, **do not** rely on running the tests in the
+sandbox. Instead, push the branch, wait for a PR to be opened, and
+examine the **CI** state for the test results. Investigate and address
+CI failures from there.
+
+The **unit** lane, however, usually *can* be run in the sandbox, since
+it needs no Docker -- install PHPUnit somewhere outside the repository
+(e.g. `composer require --dev phpunit/phpunit` in a scratch directory)
+and point it at the files:
+
+```
+$ phpunit --no-configuration tests/unit/
+```
+
+Prefer doing that over pushing blind: it is much faster than a CI
+round-trip, and any framework logic that can be tested this way should
+be.
 
 If you are running locally (not in a remote/web session) with a working
-Docker setup, just run the suite directly with `grunt test`.
+Docker setup, just run the whole suite directly with `grunt test`.
 
 ## Code coverage
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,35 @@ from one table into the next) should set
 they share the test's pool.  See `tests/LegacyTest.php` for full
 examples.
 
+### LocalArena's own test suite
+
+Everything above is about testing *a game*. LocalArena also has tests
+for *itself*, under `tests/`, in two lanes:
+
+- **Integration tests** (`tests/*Test.php`) drive a real table against
+  a real database, using the same `IntegrationTestCase` fixtures that
+  games use. They exercise the framework the way a game does, and they
+  need the Docker stack running.
+
+- **Unit tests** (`tests/unit/*Test.php`) exercise framework code that
+  can be tested in isolation -- argument parsing, pure helpers -- with
+  no table and no database. They need only a PHP interpreter and
+  PHPUnit, which makes them fast, and runnable in environments where
+  Docker is not available.
+
+Most framework behavior is only observable by driving a table, so the
+integration lane is the default; reach for the unit lane when the code
+under test genuinely does not need one. Both lanes are collected by
+`tests/phpunit.xml`, so `grunt test` runs them together.
+
+Both use the bundled `localarenanoop` game (`src/game/localarenanoop`)
+as a harness: a game that does as little as possible, so that tests
+observe the framework rather than a game's behavior. A test that needs
+different *behavior* subclasses it via `TableParams::$table_class`
+(see `tests/JumpToStateTest.php`); a test that needs different *files*
+on disk -- a different schema, different `gameinfos.inc.php` -- needs a
+new harness game beside it.
+
 ### Generating code-coverage reports
 
 The `testenv` image ships with the [PCOV](https://github.com/krakjoe/pcov)

--- a/src/module/table/APP_GameAction.php
+++ b/src/module/table/APP_GameAction.php
@@ -41,17 +41,27 @@ class APP_GameAction
   }
 
   /**
+   * Reads, validates, and converts one request argument.
+   *
+   * An argument that is absent is an error only if $required; otherwise
+   * $default is returned unconverted (it is a value the caller chose,
+   * not request input, so there is nothing to validate).  BGA's
+   * signature names this parameter $default -- see `_ide_helper.php`,
+   * `getArg(string $argName, int $argType, bool $bMandatory = false,
+   * mixed $default = null, array $argTypeDetails = [], ...)` -- so we
+   * match that name, and games passing it by name still work.
+   *
+   * N.B.: BGA's trailing $bCanFail parameter is not implemented here.
+   *
    * @param string $arg
    * @param int $type
    * @param bool $required
-   *
-   * TODO: This is a great candidate for unit testing!  I'm also not
-   * positive that the behavior matches BGA exactly (e.g. the return
-   * types may not be identical, and so on).
+   * @param mixed $default
+   * @param array $enumValues Possible values for AT_enum (BGA calls this $argTypeDetails).
    *
    * @return mixed
    */
-  function getArg($arg, $type, $required = false, $unknownParam = null, $enumValues = [])
+  function getArg($arg, $type, $required = false, $default = null, $enumValues = [])
   {
     if (isset($this->params[$arg])) {
       $rawVal = $this->params[$arg];
@@ -116,12 +126,17 @@ class APP_GameAction
         case AT_json:
           return json_decode($rawVal, /*associative=*/ true);
       }
-    } else {
-      if ($required) {
-        throw new feException('Required parameter ' . $arg . ' not found.');
-      }
+
+      // The argument was supplied, but we were asked to convert it as
+      // a type we don't recognize.
+      throw new feException('Unsupported arg type: ' . $type);
     }
-    throw new feException('Unsupported arg type: ' . $type);
+
+    if ($required) {
+      throw new feException('Required parameter ' . $arg . ' not found.');
+    }
+
+    return $default;
   }
 
   /**

--- a/tests/unit/GetArgTest.php
+++ b/tests/unit/GetArgTest.php
@@ -1,0 +1,384 @@
+<?php declare(strict_types=1);
+
+namespace LocalArena\Test\Unit;
+
+require_once __DIR__ . '/UnitTestCase.php';
+
+require_once localarenaFrameworkPath('module/table/feException.php');
+require_once localarenaFrameworkPath('module/table/APP_GameAction.php');
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for `APP_GameAction::getArg()`, which reads, validates, and
+ * converts the arguments of an incoming action request.
+ *
+ * This is the framework's front door for everything a client sends:
+ * every `act*()` method in every game reaches its parameters through
+ * it.  It is also pure -- no table, no database -- which makes it the
+ * natural first resident of the unit lane (see `UnitTestCase`).
+ *
+ * BGA's signature, from `_ide_helper.php`:
+ *
+ *     getArg(string $argName, int $argType, bool $bMandatory = false,
+ *            mixed $default = null, array $argTypeDetails = [],
+ *            bool $bCanFail = false): mixed
+ *
+ * LocalArena implements all but `$bCanFail`.
+ */
+class GetArgTest extends UnitTestCase
+{
+    // Builds an action object carrying the given request parameters.
+    // Real requests arrive over HTTP, so every value is a string.
+    private function action(array $params): \APP_GameAction
+    {
+        $act = new \APP_GameAction();
+        $act->params = $params;
+        return $act;
+    }
+
+    private function getArg(array $params, string $name, int $type, ...$rest)
+    {
+        return $this->action($params)->getArg($name, $type, ...$rest);
+    }
+
+    // Asserts that reading $name as $type rejects the value.
+    private function assertRejects(array $params, string $name, int $type, ...$rest): void
+    {
+        $this->expectException(\feException::class);
+        $this->getArg($params, $name, $type, ...$rest);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // Presence, absence, and defaults.
+
+    public function testReturnsTheConvertedValueWhenPresent(): void
+    {
+        $this->assertSame(5, $this->getArg(['n' => '5'], 'n', AT_int));
+    }
+
+    /**
+     * An absent argument that was not required is not an error: the
+     * caller's $default comes back.  Games rely on this for optional
+     * parameters -- e.g. `emppty.action.php` reads
+     * `getArg("row", AT_posint)` with no default at all.
+     */
+    public function testReturnsNullForAnAbsentOptionalArgument(): void
+    {
+        $this->assertNull($this->getArg([], 'missing', AT_int));
+    }
+
+    public function testReturnsTheGivenDefaultForAnAbsentOptionalArgument(): void
+    {
+        $this->assertSame(42, $this->getArg([], 'missing', AT_int, /*required=*/ false, /*default=*/ 42));
+    }
+
+    /**
+     * The default is the caller's own value, not request input, so it
+     * is handed back as-is rather than being validated or converted as
+     * $type.
+     */
+    public function testDoesNotConvertOrValidateTheDefault(): void
+    {
+        $this->assertSame(
+            'not an int at all',
+            $this->getArg([], 'missing', AT_int, /*required=*/ false, /*default=*/ 'not an int at all')
+        );
+    }
+
+    public function testThrowsForAnAbsentRequiredArgument(): void
+    {
+        $this->expectException(\feException::class);
+        $this->expectExceptionMessage('Required parameter missing not found.');
+        $this->getArg([], 'missing', AT_int, /*required=*/ true);
+    }
+
+    /**
+     * Presence is tested with `isset()`, so a null-valued parameter
+     * counts as absent -- including when it is required.
+     */
+    public function testTreatsANullValuedParameterAsAbsent(): void
+    {
+        $this->assertSame(7, $this->getArg(['n' => null], 'n', AT_int, /*required=*/ false, /*default=*/ 7));
+    }
+
+    public function testThrowsForAnUnrecognizedType(): void
+    {
+        $this->expectException(\feException::class);
+        $this->expectExceptionMessage('Unsupported arg type: 999');
+        $this->getArg(['n' => '5'], 'n', 999);
+    }
+
+    public function testIsArgReportsPresence(): void
+    {
+        $act = $this->action(['present' => '1', 'null_valued' => null]);
+        $this->assertTrue($act->isArg('present'));
+        $this->assertFalse($act->isArg('absent'));
+        $this->assertFalse($act->isArg('null_valued'));
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // AT_int / AT_posint
+
+    public static function validIntProvider(): array
+    {
+        return [
+            'positive' => ['5', 5],
+            'zero' => ['0', 0],
+            'negative' => ['-5', -5],
+            'leading zeroes' => ['007', 7],
+        ];
+    }
+
+    #[DataProvider('validIntProvider')]
+    public function testAtInt(string $raw, int $expected): void
+    {
+        $this->assertSame($expected, $this->getArg(['n' => $raw], 'n', AT_int));
+    }
+
+    public static function invalidIntProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'decimal' => ['5.5'],
+            'alphabetic' => ['abc'],
+            'trailing garbage' => ['5x'],
+            'leading space' => [' 5'],
+            'plus sign' => ['+5'],
+        ];
+    }
+
+    #[DataProvider('invalidIntProvider')]
+    public function testAtIntRejects(string $raw): void
+    {
+        $this->assertRejects(['n' => $raw], 'n', AT_int);
+    }
+
+    public function testAtPosint(): void
+    {
+        $this->assertSame(5, $this->getArg(['n' => '5'], 'n', AT_posint));
+        $this->assertSame(0, $this->getArg(['n' => '0'], 'n', AT_posint));
+    }
+
+    /**
+     * The difference between AT_int and AT_posint is exactly the sign.
+     */
+    public function testAtPosintRejectsNegativeNumbers(): void
+    {
+        $this->assertRejects(['n' => '-5'], 'n', AT_posint);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // AT_float
+
+    public function testAtFloat(): void
+    {
+        $this->assertSame(5.5, $this->getArg(['n' => '5.5'], 'n', AT_float));
+        $this->assertSame(-5.5, $this->getArg(['n' => '-5.5'], 'n', AT_float));
+        // An integral value still comes back as a float.
+        $this->assertSame(5.0, $this->getArg(['n' => '5'], 'n', AT_float));
+    }
+
+    public static function invalidFloatProvider(): array
+    {
+        return [
+            'no leading digit' => ['.5'],
+            'no trailing digit' => ['5.'],
+            'alphabetic' => ['abc'],
+            'exponent notation' => ['1e3'],
+            'two points' => ['1.2.3'],
+        ];
+    }
+
+    #[DataProvider('invalidFloatProvider')]
+    public function testAtFloatRejects(string $raw): void
+    {
+        $this->assertRejects(['n' => $raw], 'n', AT_float);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // AT_bool
+
+    public function testAtBool(): void
+    {
+        $this->assertTrue($this->getArg(['b' => '1'], 'b', AT_bool));
+        $this->assertTrue($this->getArg(['b' => 'true'], 'b', AT_bool));
+        $this->assertFalse($this->getArg(['b' => '0'], 'b', AT_bool));
+        $this->assertFalse($this->getArg(['b' => 'false'], 'b', AT_bool));
+    }
+
+    public static function invalidBoolProvider(): array
+    {
+        return [
+            'yes' => ['yes'],
+            'capitalized' => ['True'],
+            'empty' => [''],
+            'number' => ['2'],
+        ];
+    }
+
+    #[DataProvider('invalidBoolProvider')]
+    public function testAtBoolRejects(string $raw): void
+    {
+        $this->assertRejects(['b' => $raw], 'b', AT_bool);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // AT_enum
+
+    public function testAtEnumReturnsTheRawValue(): void
+    {
+        $this->assertSame(
+            'red',
+            $this->getArg(['c' => 'red'], 'c', AT_enum, /*required=*/ false, /*default=*/ null, ['red', 'blue'])
+        );
+    }
+
+    public function testAtEnumRejectsAValueNotInTheList(): void
+    {
+        $this->expectException(\feException::class);
+        $this->expectExceptionMessage('Invalid value for argument of type AT_enum: green (possible values: red, blue)');
+        $this->getArg(['c' => 'green'], 'c', AT_enum, /*required=*/ false, /*default=*/ null, ['red', 'blue']);
+    }
+
+    /**
+     * With no list supplied, nothing can be valid.
+     */
+    public function testAtEnumRejectsEverythingWhenTheListIsEmpty(): void
+    {
+        $this->assertRejects(['c' => 'red'], 'c', AT_enum);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // AT_alphanum / AT_alphanum_dash
+
+    public function testAtAlphanum(): void
+    {
+        $this->assertSame('abc123', $this->getArg(['s' => 'abc123'], 's', AT_alphanum));
+        $this->assertSame('with space', $this->getArg(['s' => 'with space'], 's', AT_alphanum));
+    }
+
+    public static function invalidAlphanumProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'dash' => ['a-b'],
+            'punctuation' => ['a.b'],
+            'quote' => ["a'b"],
+            'angle bracket' => ['<b>'],
+        ];
+    }
+
+    #[DataProvider('invalidAlphanumProvider')]
+    public function testAtAlphanumRejects(string $raw): void
+    {
+        $this->assertRejects(['s' => $raw], 's', AT_alphanum);
+    }
+
+    public function testAtAlphanumDashAllowsDashes(): void
+    {
+        $this->assertSame('a-b 1', $this->getArg(['s' => 'a-b 1'], 's', AT_alphanum_dash));
+    }
+
+    public function testAtAlphanumDashRejectsOtherPunctuation(): void
+    {
+        $this->assertRejects(['s' => 'a.b'], 's', AT_alphanum_dash);
+    }
+
+    /**
+     * Both AT_alphanum and AT_alphanum_dash currently reject the
+     * underscore, even though the comments on their `define()`s
+     * describe it as allowed ("a string with 0-9a-zA-Z_ and space").
+     *
+     * These two assertions pin down what the code does TODAY rather
+     * than endorsing it: if the regexes are corrected to match the
+     * documented character set, these are the tests that should fail
+     * and be updated, deliberately.
+     */
+    public function testAtAlphanumTypesRejectUnderscoresDespiteTheirDocumentation(): void
+    {
+        $this->assertRejects(['s' => 'a_b'], 's', AT_alphanum);
+    }
+
+    public function testAtAlphanumDashRejectsUnderscores(): void
+    {
+        $this->assertRejects(['s' => 'a_b'], 's', AT_alphanum_dash);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // AT_numberlist
+
+    /**
+     * N.B.: AT_numberlist validates but does not parse; the raw string
+     * comes back, and callers split it themselves (as
+     * `burglebrostwo.action.php` does with `explode()`).
+     */
+    public static function validNumberlistProvider(): array
+    {
+        return [
+            'single' => ['1'],
+            'comma separated' => ['1,4,2'],
+            'semicolon separated' => ['1;4;2'],
+            'mixed separators' => ['1,4;2,3'],
+            'negative values' => ['-1,2'],
+        ];
+    }
+
+    #[DataProvider('validNumberlistProvider')]
+    public function testAtNumberlistReturnsTheRawString(string $raw): void
+    {
+        $this->assertSame($raw, $this->getArg(['l' => $raw], 'l', AT_numberlist));
+    }
+
+    public static function invalidNumberlistProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'trailing separator' => ['1,'],
+            'leading separator' => [',1'],
+            'doubled separator' => ['1,,2'],
+            'spaces' => ['1, 2'],
+            'non-numeric' => ['1,a'],
+        ];
+    }
+
+    #[DataProvider('invalidNumberlistProvider')]
+    public function testAtNumberlistRejects(string $raw): void
+    {
+        $this->assertRejects(['l' => $raw], 'l', AT_numberlist);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // AT_base64 / AT_json
+
+    public function testAtBase64Decodes(): void
+    {
+        $this->assertSame('hello', $this->getArg(['s' => base64_encode('hello')], 's', AT_base64));
+    }
+
+    /**
+     * Decoding is strict, but a failure is reported by returning false
+     * rather than by throwing -- unlike every other type here.
+     */
+    public function testAtBase64ReturnsFalseForUndecodableInput(): void
+    {
+        $this->assertFalse($this->getArg(['s' => 'not!valid!base64'], 's', AT_base64));
+    }
+
+    public function testAtJsonDecodesToAnAssociativeArray(): void
+    {
+        $this->assertSame(
+            ['a' => 1, 'b' => [2, 3]],
+            $this->getArg(['j' => '{"a":1,"b":[2,3]}'], 'j', AT_json)
+        );
+    }
+
+    /**
+     * As with AT_base64, malformed input is not an exception; it
+     * decodes to null.
+     */
+    public function testAtJsonReturnsNullForMalformedInput(): void
+    {
+        $this->assertNull($this->getArg(['j' => '{not json'], 'j', AT_json));
+    }
+}

--- a/tests/unit/UnitTestCase.php
+++ b/tests/unit/UnitTestCase.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace LocalArena\Test\Unit;
+
+/**
+ * Base class for LocalArena's UNIT tests.
+ *
+ * Unlike `IntegrationTestCase`, this does not create a table, does not
+ * touch MySQL, and does not require the LocalArena Docker stack to be
+ * running.  It is for framework code that can be exercised in
+ * isolation: argument parsing, pure helpers, data-shape rendering, and
+ * so on.
+ *
+ * Two reasons that lane is worth having:
+ *
+ * - It is fast.  There is no table to create and no database to talk
+ *   to, so these tests cost milliseconds.
+ *
+ * - It is runnable where the integration suite is not.  The
+ *   integration tests need Docker plus a running MySQL service (see
+ *   CLAUDE.md); these need only a PHP interpreter, so they can be run
+ *   directly -- including in environments where the Docker daemon and
+ *   image registry are unavailable.
+ *
+ * Unit tests live in `tests/unit/` and are named `*Test.php`, so they
+ * are collected by `tests/phpunit.xml` and sharded by CI exactly like
+ * the integration tests; no separate wiring is needed.
+ */
+class UnitTestCase extends \PHPUnit\Framework\TestCase
+{
+}
+
+/**
+ * Resolves a path beneath the LocalArena framework sources
+ * (i.e. what the repository keeps in `src/`).
+ *
+ * Unit tests are run in two different layouts, and this papers over
+ * the difference:
+ *
+ * - Inside the `testenv` container, where `src/module` is mounted at
+ *   `/src/localarena/module` and `APP_GAMEMODULE_PATH` has been
+ *   defined (by the PHPUnit bootstrap, `IntegrationTestCase.php`).
+ *
+ * - Straight from a checkout, where the sources are at `<repo>/src`
+ *   and no constants have been defined at all -- the case that lets
+ *   these tests run without Docker.
+ */
+function localarenaFrameworkPath(string $relative_path): string
+{
+  $root = defined('APP_GAMEMODULE_PATH') ? APP_GAMEMODULE_PATH : dirname(__DIR__, 2) . '/src/';
+  return rtrim($root, '/') . '/' . ltrim($relative_path, '/');
+}


### PR DESCRIPTION
First chunk of the test-coverage work. Small on purpose: it lands one
well-covered surface and sets up the lane that later pure-logic tests
will use.

## The bug

`APP_GameAction::getArg()` is the framework's front door for everything a
client sends — every `act*()` in every game reaches its parameters through
it — and it had no tests. Its docblock said as much: *"This is a great
candidate for unit testing!"*

Writing them turned one up. An argument that was absent and **not**
required fell past the `else` branch into the trailing `throw`:

```php
if (isset($this->params[$arg])) {
    switch ($type) { /* ... every case returns ... */ }
} else {
    if ($required) { throw new feException('Required parameter ...'); }
}
throw new feException('Unsupported arg type: ' . $type);   // <- always reached
```

So every optional argument raised `feException: Unsupported arg type: <n>`.
There was no path that returned without throwing. This is reachable from a
bundled game — `emppty.action.php:65` calls `getArg("row", AT_posint)`.

## The fix

The fourth parameter turns out to be the answer. It was named
`$unknownParam` and ignored, but `_ide_helper.php:1553` has BGA's real
signature:

```php
getArg(string $argName, int $argType, bool $bMandatory = false,
       mixed $default = null, array $argTypeDetails = [],
       bool $bCanFail = false): mixed
```

It is BGA's `$default`. So:

- an absent, non-required argument now returns `$default` (null unless the
  caller says otherwise), which is what the BGA signature promises;
- the parameter is renamed `$default` to match — this also makes calls that
  pass it by name work, which they could not before;
- the "unsupported type" throw moves inside the `isset()` branch, where it
  means what it says.

`$bCanFail` is still not implemented; that is now noted in the docblock
rather than left implicit.

## The unit lane

These tests need no table and no database, so instead of extending
`IntegrationTestCase` they introduce a second lane under `tests/unit/`,
with a `UnitTestCase` base and a small path helper that resolves the
framework sources in both layouts tests run in (mounted at
`/src/localarena` inside the `testenv` container, or `<repo>/src` straight
from a checkout).

No wiring was needed: `tests/phpunit.xml` collects `tests/` recursively,
and the CI shard discovery already does `find tests -name '*Test.php'`,
which is recursive too. So these shard alongside the integration tests and
`grunt test` runs both.

The lane earns its keep for a second reason: it is runnable **without
Docker**, which the integration lane is not. Per `CLAUDE.md`, web sessions
can't run the integration suite and have to push and read CI; anything
testable this way can now be verified in seconds instead. `CLAUDE.md` and
`README.md` are updated to describe both lanes.

## Coverage

59 tests over all ten `AT_*` types — valid and invalid input for each —
plus presence/absence, `$required`, `$default`, and `isArg()`. Verified
locally against PHP 8.4 / PHPUnit 11: green with the fix, and 4 errors
without it, so the tests do catch the bug they were written for.

## One thing I did not change

Two tests pin down current behavior that looks wrong, rather than changing
it blind:

```php
define('AT_alphanum', 6);       // "a string with 0-9a-zA-Z_ and space"
    preg_match('/^[0-9a-zA-Z ]+$/', $rawVal)      // no underscore

define('AT_alphanum_dash', 7);  // "a string with 0-9a-zA-Z_- and space"
    preg_match('/^[-0-9a-zA-Z ]+$/', $rawVal)     // no underscore
```

Both comments say the underscore is allowed; neither regex allows it. Two
independent sites disagreeing the same way suggests the comments were
copied from BGA's docs and the regexes are wrong — but I can't verify
BGA's actual character set, and tightening or loosening input validation
isn't something to guess at. The tests assert today's behavior and say
plainly that they are the ones to update if the regexes are corrected.
Happy to fix it in a follow-up if you know which way it should go.

## Next chunks

Roughly in this order, each its own PR — full plan and gap inventory
[here](https://claude.ai/code/artifact/277ad321-6167-4250-b7a2-492de4dc8fda):

1. Notif fixtures (`notifs()`, a recording `gameServer`), then tests for
   the notification/gamelog path — the largest untested surface, and
   `TODO.md` already asks for the fixtures.
2. Per-table player count. `TableParams::$playerCount` is currently dead —
   `stGameSetup()` reads the `LOCALARENA_PLAYER_COUNT` constant — so the
   whole suite runs at exactly 2 players. Lifting it unblocks turn-order
   and multiactive tests at 3 and 4.
3. `deck.php` — 302 lines, zero coverage, and the component games lean on
   most. Needs a harness game with a `card` table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFpz5SLnPcJcWAYYrteHbU)_