### PR TITLE
Honor TableParams::$playerCount, and test turn order

### DIFF
--- a/src/module/table/table.game.php
+++ b/src/module/table/table.game.php
@@ -459,6 +459,10 @@
    // parked state) by `getLiveStateId()`.
    private ?int $liveStateId_ = null;
 
+   // How many players this table seats; null means
+   // `LOCALARENA_PLAYER_COUNT`.  See `localarenaSetPlayerCount()`.
+   private ?int $localarena_player_count_ = null;
+
    function __construct()
    {
      parent::__construct();
@@ -513,6 +517,34 @@
    {
      $this->localarena_table_options_ = $options;
      $this->localarena_allow_unpublished_option_values_ = $allow_unpublished_option_values;
+   }
+
+   // Records how many players this table seats.  Must be called before
+   // `initTable()`, which runs game setup; see
+   // `TableManager::createTable()`.
+   //
+   // Null means "use the configured default", i.e.
+   // `LOCALARENA_PLAYER_COUNT`, which is what interactive play does.
+   public function localarenaSetPlayerCount(?int $player_count): void
+   {
+     if ($player_count !== null && $player_count < 1) {
+       throw new \BgaVisibleSystemException(
+         'A table must seat at least one player; was asked for ' . $player_count . '.'
+       );
+     }
+     $this->localarena_player_count_ = $player_count;
+   }
+
+   // The number of players this table seats.
+   //
+   // This is per-table rather than global so that a test can create
+   // tables of different sizes: `LOCALARENA_PLAYER_COUNT` is a `const`
+   // baked into the image, so before this existed every table in the
+   // process -- and therefore every test -- had exactly the same
+   // number of players.
+   public function localarenaPlayerCount(): int
+   {
+     return $this->localarena_player_count_ ?? LOCALARENA_PLAYER_COUNT;
    }
 
    function localarenaSetDefaultOptions()
@@ -1029,7 +1061,12 @@
      return intval($this->getPlayerRowById($player_id)['player_no']);
    }
 
-   function getPlayerColorById(int $player_id): int
+   // N.B.: A player color is a six-character hex string ('ff0000'),
+   // not a number.  This was declared `: int`, which made it either
+   // fatal or silently wrong for every color a game defines --
+   // 'ff0000' raised a TypeError, while '008000' was coerced to the
+   // integer 8000.
+   function getPlayerColorById(int $player_id): string
    {
      return $this->getPlayerRowById($player_id)['player_color'];
    }
@@ -1179,7 +1216,7 @@
      $first_player_id = self::LOCALARENA_FIRST_PLAYER_ID;
 
      $players = [];
-     for ($i = 0; $i < LOCALARENA_PLAYER_COUNT; $i++) {
+     for ($i = 0; $i < $this->localarenaPlayerCount(); $i++) {
        $player_id = $first_player_id + $i;
        $players[$player_id] = [
          'player_no' => $i + 1,

--- a/src/module/tablemanager/TableParams.php
+++ b/src/module/tablemanager/TableParams.php
@@ -5,7 +5,16 @@ namespace LocalArena;
 class TableParams
 {
     public string $game;
-    public int $playerCount;
+
+    // The number of players to seat at this table.
+    //
+    // Null (the default) means the count configured for interactive
+    // play, `LOCALARENA_PLAYER_COUNT` in
+    // "localarena_config.inc.php".  Tests that exercise
+    // player-count-dependent behavior -- turn order, multiactive sets
+    // -- set it explicitly in their `defaultTableParams()` override;
+    // see `tests/PlayerOrderTest.php`.
+    public ?int $playerCount = null;
 
     // Iff true, the "dbmodel.sql" file will be loaded at table
     // creation.  Setting this false is sometimes useful in test

--- a/src/module/tablemanager/tablemanager.php
+++ b/src/module/tablemanager/tablemanager.php
@@ -134,6 +134,7 @@ class TableManager
     // state, which applies the option defaults and then calls
     // `setupNewGame()`.
     $game->localarenaSetTableOptions($params->game_options, $params->allow_unpublished_option_values);
+    $game->localarenaSetPlayerCount($params->playerCount);
 
     $game->initTable($params->load_schema_file);
 

--- a/src/module/test/IntegrationTestCase.php
+++ b/src/module/test/IntegrationTestCase.php
@@ -332,9 +332,23 @@ class IntegrationTestCase extends \PHPUnit\Framework\TestCase
 
   // Returns the IDs of all players that `stGameSetup()` will seat (in
   // seating order).  Valid before the table exists.
-  public static function presetPlayerIds(): array
+  public function presetPlayerIds(): array
   {
-    return array_map(fn($i) => self::presetPlayerId($i), range(0, LOCALARENA_PLAYER_COUNT - 1));
+    return array_map(fn($i) => self::presetPlayerId($i), range(0, $this->playerCount() - 1));
+  }
+
+  // The number of players this test's table seats.
+  //
+  // Valid before the table exists -- it comes from
+  // `defaultTableParams()` until there is a table to ask -- which is
+  // what the legacy-seeding helpers need, since they run before table
+  // creation.
+  public function playerCount(): int
+  {
+    if ($this->table_ === null) {
+      return $this->defaultTableParams()->playerCount ?? LOCALARENA_PLAYER_COUNT;
+    }
+    return $this->table_->localarenaPlayerCount();
   }
 
   private function legacyStore(): \LocalArenaLegacyStore
@@ -359,7 +373,7 @@ class IntegrationTestCase extends \PHPUnit\Framework\TestCase
   // before the table is set up.
   public function seedLegacyTeamData($value, ?array $player_ids = null, int $ttl = 365): void
   {
-    $signature = localarenaLegacyTeamSignature($player_ids ?? self::presetPlayerIds());
+    $signature = localarenaLegacyTeamSignature($player_ids ?? $this->presetPlayerIds());
     $this->legacyStore()->setTeamData($signature, json_encode($value), $ttl);
   }
 
@@ -380,7 +394,7 @@ class IntegrationTestCase extends \PHPUnit\Framework\TestCase
   // $default if there is none; for assertions.
   public function legacyTeamValue(?array $player_ids = null, $default = null)
   {
-    $signature = localarenaLegacyTeamSignature($player_ids ?? self::presetPlayerIds());
+    $signature = localarenaLegacyTeamSignature($player_ids ?? $this->presetPlayerIds());
     $json = $this->legacyStore()->getTeamData($signature);
     if ($json === null) {
       return $default;

--- a/tests/PlayerOrderTest.php
+++ b/tests/PlayerOrderTest.php
@@ -1,0 +1,280 @@
+<?php declare(strict_types=1);
+
+namespace LocalArena\Test;
+
+require_once __DIR__ . '/../module/test/IntegrationTestCase.php';
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for seating and turn order: `getNextPlayerTable()`,
+ * `getPrevPlayerTable()`, `getPlayerAfter()`, `getPlayerBefore()`,
+ * `activeNextPlayer()`, and `getPlayerRelativePositions()`.
+ *
+ * These had no tests, and until now could not really have had useful
+ * ones: `stGameSetup()` seated `LOCALARENA_PLAYER_COUNT` players, a
+ * `const` baked into the testenv image at 2, so every table in the
+ * suite was the same size.  Turn order around a two-player table is
+ * nearly degenerate -- "next" and "previous" are the same player --
+ * so it cannot distinguish a correct implementation from several
+ * wrong ones.
+ *
+ * `TableParams::$playerCount` is now honored, so each test here says
+ * how many players it wants and the interesting cases are reachable.
+ */
+class PlayerOrderTest extends IntegrationTestCase
+{
+    const LOCALARENA_GAME_NAME = 'localarenanoop';
+
+    // How many players this test's table seats.  Because the table is
+    // created lazily -- on the first call that needs it -- a test can
+    // set this first and have it apply, which is what `seat()` does.
+    private int $player_count_ = 2;
+
+    protected function defaultTableParams(): \LocalArena\TableParams
+    {
+        $params = parent::defaultTableParams();
+        $params->playerCount = $this->player_count_;
+        return $params;
+    }
+
+    // Seats $count players and returns their IDs in seating order.
+    // Must be called before anything else touches the table.
+    private function seat(int $count): array
+    {
+        $this->player_count_ = $count;
+        return array_map(fn($p) => $p->id(), $this->players());
+    }
+
+    public static function tableSizeProvider(): array
+    {
+        return [
+            '2 players' => [2],
+            '3 players' => [3],
+            '4 players' => [4],
+        ];
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // Seating.
+
+    /**
+     * The premise of everything below: a table seats the number of
+     * players it was created with.
+     */
+    #[DataProvider('tableSizeProvider')]
+    public function testSeatsTheRequestedNumberOfPlayers(int $count): void
+    {
+        $this->assertCount($count, $this->seat($count));
+    }
+
+    /**
+     * Seats are numbered from 1, in ascending player-ID order, with no
+     * gaps -- which is what makes `player_no` usable as a ring index.
+     */
+    #[DataProvider('tableSizeProvider')]
+    public function testAssignsConsecutiveSeatNumbersInPlayerIdOrder(int $count): void
+    {
+        $this->seat($count);
+
+        $seats = [];
+        foreach ($this->players() as $player) {
+            $seats[] = $player->no();
+        }
+        sort($seats);
+
+        $this->assertSame(range(1, $count), $seats);
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // The turn-order rings.
+
+    #[DataProvider('tableSizeProvider')]
+    public function testNextPlayerTableCyclesThroughTheSeatingOrder(int $count): void
+    {
+        $ids = $this->seat($count);
+        $next = $this->table()->getNextPlayerTable();
+
+        foreach ($ids as $i => $id) {
+            $this->assertSame(
+                intval($ids[($i + 1) % $count]),
+                $next[$id],
+                'The player after seat ' . ($i + 1) . ' should be the next one around the table.'
+            );
+        }
+    }
+
+    #[DataProvider('tableSizeProvider')]
+    public function testPrevPlayerTableIsTheInverseOfTheNextTable(int $count): void
+    {
+        $ids = $this->seat($count);
+        $prev = $this->table()->getPrevPlayerTable();
+
+        foreach ($ids as $i => $id) {
+            $this->assertSame(
+                intval($ids[($i - 1 + $count) % $count]),
+                $prev[$id],
+                'The player before seat ' . ($i + 1) . ' should be the previous one around the table.'
+            );
+        }
+    }
+
+    /**
+     * `getPlayerAfter()` and `getPlayerBefore()` are the single-player
+     * views of those two tables, and must agree with them.
+     */
+    #[DataProvider('tableSizeProvider')]
+    public function testGetPlayerAfterAndBeforeAgreeWithTheTables(int $count): void
+    {
+        $ids = $this->seat($count);
+        $table = $this->table();
+
+        foreach ($ids as $i => $id) {
+            $this->assertSame(intval($ids[($i + 1) % $count]), $table->getPlayerAfter($id));
+            $this->assertSame(intval($ids[($i - 1 + $count) % $count]), $table->getPlayerBefore($id));
+        }
+    }
+
+    /**
+     * With three or more players, "after" and "before" are genuinely
+     * different directions.  At two players they coincide, which is
+     * why a two-player-only suite could not tell the tables apart.
+     */
+    public function testAfterAndBeforeDifferOnceTheTableIsLargerThanTwo(): void
+    {
+        $ids = $this->seat(3);
+        $table = $this->table();
+
+        $this->assertNotSame($table->getPlayerAfter($ids[0]), $table->getPlayerBefore($ids[0]));
+        $this->assertSame(intval($ids[1]), $table->getPlayerAfter($ids[0]));
+        $this->assertSame(intval($ids[2]), $table->getPlayerBefore($ids[0]));
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // Advancing the active player.
+
+    /**
+     * Repeatedly advancing visits every player exactly once and
+     * arrives back where it started.
+     */
+    #[DataProvider('tableSizeProvider')]
+    public function testActiveNextPlayerGoesAllTheWayAroundTheTable(int $count): void
+    {
+        $ids = $this->seat($count);
+        $table = $this->table();
+
+        $table->changeActivePlayer(intval($ids[0]));
+        $this->assertSame(intval($ids[0]), intval($table->getActivePlayerId()));
+
+        $visited = [];
+        for ($i = 0; $i < $count; $i++) {
+            $visited[] = intval($table->activeNextPlayer());
+        }
+
+        $expected = array_map('intval', array_merge(array_slice($ids, 1), [$ids[0]]));
+        $this->assertSame($expected, $visited);
+
+        // Having gone all the way around, we are back at the start.
+        $this->assertSame(intval($ids[0]), intval($table->getActivePlayerId()));
+    }
+
+    /**
+     * `activeNextPlayer()` both returns the new active player and
+     * makes them active; a game that trusts either alone should get
+     * the same answer.
+     */
+    public function testActiveNextPlayerReturnsThePlayerItActivates(): void
+    {
+        $ids = $this->seat(3);
+        $table = $this->table();
+
+        $table->changeActivePlayer(intval($ids[0]));
+        $returned = $table->activeNextPlayer();
+
+        $this->assertSame(intval($returned), intval($table->getActivePlayerId()));
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // Relative positions.
+
+    /**
+     * `getPlayerRelativePositions()` is what puts the viewer at the
+     * bottom of their own screen: the current player is position 0,
+     * and everyone else follows in turn order.
+     */
+    #[DataProvider('tableSizeProvider')]
+    public function testRelativePositionsPutTheCurrentPlayerFirst(int $count): void
+    {
+        $ids = $this->seat($count);
+        $table = $this->table();
+
+        // Look at the table through each player's eyes in turn.
+        foreach ($ids as $viewer_index => $viewer_id) {
+            $previous_current_player = $table->currentPlayer;
+            $table->currentPlayer = intval($viewer_id);
+            try {
+                $positions = $table->getPlayerRelativePositions();
+            } finally {
+                $table->currentPlayer = $previous_current_player;
+            }
+
+            $this->assertSame(
+                0,
+                $positions[$viewer_id],
+                'The current player should always be at relative position 0.'
+            );
+
+            // Everyone else is at their distance around the ring.
+            foreach ($ids as $i => $id) {
+                $expected_position = ($i - $viewer_index + $count) % $count;
+                $this->assertSame(
+                    $expected_position,
+                    $positions[$id],
+                    'Player at seat ' . ($i + 1) . ' seen from seat ' . ($viewer_index + 1) . '.'
+                );
+            }
+        }
+    }
+
+    //////////////////////////////////////////////////////////////////
+    // Per-player accessors.
+
+    #[DataProvider('tableSizeProvider')]
+    public function testPlayerAccessorsReportEachPlayersOwnValues(int $count): void
+    {
+        $ids = $this->seat($count);
+        $table = $this->table();
+
+        foreach ($ids as $i => $id) {
+            $this->assertSame(LOCALARENA_PLAYER_NAME_STEM . $i, $table->getPlayerNameById(intval($id)));
+            $this->assertSame($i + 1, $table->getPlayerNoById(intval($id)));
+        }
+    }
+
+    /**
+     * Player colors are six-character hex strings, so
+     * `getPlayerColorById()` has to return a string.  It was declared
+     * `: int`, which made it either fatal or silently wrong for every
+     * color in the game: 'ff0000' raised a TypeError, and '008000'
+     * came back as the integer 8000.
+     */
+    #[DataProvider('tableSizeProvider')]
+    public function testGetPlayerColorByIdReturnsTheColorItself(int $count): void
+    {
+        $ids = $this->seat($count);
+        $table = $this->table();
+
+        $colors = [];
+        foreach ($ids as $id) {
+            $color = $table->getPlayerColorById(intval($id));
+            $this->assertMatchesRegularExpression(
+                '/^[0-9a-f]{6}$/',
+                $color,
+                'A player color should be a six-digit hex string.'
+            );
+            $colors[] = $color;
+        }
+
+        $this->assertSame($colors, array_unique($colors), 'Every player should have a distinct color.');
+    }
+}


### PR DESCRIPTION
Third chunk. Independent of #28 — branched off `main`, no overlapping
files except `IntegrationTestCase.php`, where the two touch different
regions.

## The limit

`TableParams::$playerCount` was dead code. `stGameSetup()` seats
`LOCALARENA_PLAYER_COUNT` players — a `const` read from
`localarena_config.inc.php` and baked into the testenv image at 2 — so
every table in the process was the same size and **the entire suite ran
at exactly two players**. The most recent such commit is even titled
*"Write the setPlayersMultiactive tests for a two-player table"*.

That matters more than it sounds. Turn order around a two-player table is
nearly degenerate — "next" and "previous" are the same player — so a
two-player test can't distinguish a correct ring from several broken
ones. None of the turn-order functions had tests at all.

## The change

- `Table::localarenaSetPlayerCount()` / `localarenaPlayerCount()`, set by
  `TableManager::createTable()` from the params — the same shape the
  existing game-options plumbing uses. Null means "use the configured
  default", so interactive play (`index.php`, which never set a count) is
  unchanged.
- `TableParams::$playerCount` becomes `?int` defaulting to null. It was a
  non-nullable typed property with no default, so reading it when unset
  would have thrown — which is presumably part of why nothing read it.
- `IntegrationTestCase::presetPlayerIds()` follows the test's configured
  count instead of the constant, and becomes an instance method. Only the
  two legacy-seeding helpers called it, both internally;
  `presetPlayerId()` (singular) stays static, since `LegacyTest` uses it
  widely.

`defaultTableParams()` still asks for 2 players, so every existing test
sees exactly what it saw before.

## Tests

`PlayerOrderTest` runs across 2-, 3-, and 4-player tables:

- seating count and consecutive seat numbers
- `getNextPlayerTable()` cycling through seating order
- `getPrevPlayerTable()` being its inverse
- `getPlayerAfter()`/`getPlayerBefore()` agreeing with both tables, and
  *differing from each other* once there are more than two players —
  the case the old harness couldn't reach
- `activeNextPlayer()` visiting every player exactly once and returning
  to the start
- `getPlayerRelativePositions()` seen from every player's seat

## Also in here

`getPlayerColorById()` was declared `: int` while returning
`player_color`, a six-character hex string. For the colors
`localarenanoop` actually defines, that's fatal for `'ff0000'`
(TypeError) and silently wrong for `'008000'` (coerced to the integer
`8000`). One-line fix to `: string`, with a test. No caller in the tree
had ever invoked it, which is why nobody had hit it.

It's a separate concern from the player-count work and I'd normally split
it — but it's one line in a function this PR's tests were already
exercising, so a standalone PR seemed like more overhead than it's worth.
Happy to pull it out if you'd rather.

## Something I noticed but did not touch

`getPlayerRelativePositions()` has a spectator branch:

```php
$nextPlayer = self::createNextPlayerTable(...);
if (!isset($nextPlayer[$current_player])) {
    $player_id = $nextPlayer[0];   // <- createNextPlayerTable() never sets [0]
}
```

`getNextPlayerTable()` sets a `[0]` entry as a spectator default;
`createNextPlayerTable()` doesn't. So that branch reads a missing key. It's
unreachable today (tests always have a real current player, and spectators
aren't supported at all per README), so I left it alone rather than write
a test that pins down behavior nobody has designed yet.

## Verification

Same caveat as #28: no Docker here, so this rides on CI. I'll watch it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFpz5SLnPcJcWAYYrteHbU)_